### PR TITLE
Initial QVTo Transformations for SPD Semantic

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.classpath
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.classpath
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="transformations"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.gitignore
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+bin

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.project
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.project
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.spd.semantic.transformations</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2m.qvt.oml.project.QVTOBuilder</name>
+			<arguments>
+				<dictionary>
+					<key>src_container</key>
+					<value>transformations</value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2m.qvt.oml.project.QVTONature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.m2m.qvt.oml.mmodel.urimap
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.m2m.qvt.oml.mmodel.urimap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<uriMap:MappingContainer xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:uriMap="http:///www.eclipse.org/m2m/qvt/oml/MModelUriMap/1.0.0">
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#/"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//adjustments"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//triggers"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//targets"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//constraints"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//constraints/policy"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//constraints/target"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0" targetURI="platform:/resource/org.palladiosimulator.spd.semantic/model/semantic.ecore#/"/>
+</uriMap:MappingContainer>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Spd Semantic Transformations
+Bundle-SymbolicName: org.palladiosimulator.spd.semantic.transformations;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.palladiosimulator.spd.semantic.transformations
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/README.md
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/README.md
@@ -1,0 +1,26 @@
+# SPD Semantic
+
+## Introduction & Motivation
+
+This main objective of the the code in this repository is to have
+a well-defined semantic for the SPD language.
+The semantic is defined in the form of a QVT Operational mapping from PCM to PCM (incl. SPD).
+
+## Prerequisites
+
+* Eclipse Modeling Tools 2021-12
+* Java 17
+* The following meta-models installed
+  * [Palladio Component Model](https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/updatesite/releases/)
+  * [SPD Meta-Model](https://github.com/PalladioSimulator/Palladio-Addons-SPD-Metamodel)
+  * [SPD Semantic Meta-Model](https://github.com/PalladioSimulator/Palladio-Addons-SPD-Metamodel)
+
+## Executing the Transformation with the provided Example
+
+The main entry point of the transformation is the `spdtransformation.qvto` script, which can be found
+in the folder `spd.semantic.qvto`. 
+The transformation can be executed by creating a run configuration for the file and providing the models that 
+should be transformed as arguments.
+
+An example model is provided as part of this repository named `test-spd`.
+

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/README.md
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/README.md
@@ -22,5 +22,4 @@ in the folder `spd.semantic.qvto`.
 The transformation can be executed by creating a run configuration for the file and providing the models that 
 should be transformed as arguments.
 
-An example model is provided as part of this repository named `test-spd`.
 

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/plugin.xml
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.m2m.qvt.oml.runtime.qvtTransformationContainer">
+      <sourceContainer
+            path="transformations/">
+      </sourceContainer>
+   </extension>
+
+</plugin>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/archive/pcm2pcm.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/archive/pcm2pcm.qvto
@@ -1,0 +1,336 @@
+import pcm.helpers.Commons;
+import pcm.helpers.Constructors;
+import pcm.helpers.Wiring;
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_USAGE uses 'http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2';
+modeltype PCM_FEATURE_CONF uses 'http://sdq.ipd.uka.de/FeatureConfig/2.0';
+modeltype PCM_FEATURE_MOD uses 'http://sdq.ipd.uka.de/FeatureModel/2.0';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+transformation pcm2pcm(	inout pcmAllocation : PCM_ALLOC,
+									inout pcmSystem : PCM_SYS,
+									inout pcmResourceEnvironment : PCM_RES_ENV,
+									inout repository : PCM_REP,
+									in spd : SPD_MOD,
+									inout spdSemantic : SPD_SEM );
+
+main() {
+	var mySPD : SPD = spd.objects()[SPD]->any(true);
+	log('Used SPD for transformation {name: '+mySPD.entityName+'}');	
+
+	var scalingPolicy : ScalingPolicy = mySPD.scalingPolicies->any(true);
+	log('Used ScalingPolicy for transformation {name: '+scalingPolicy.entityName+'}');
+	
+	var resEnv : ResourceEnvironment = pcmResourceEnvironment.objects()[ResourceEnvironment]->any(true);
+	var system : System = pcmSystem.objects()[System]->any(true);
+	var allocation : Allocation = pcmAllocation.objects()[Allocation]->any(true);
+	var rep : Repository = repository.objects()[Repository]->any(true);
+	resEnv->map absoluteAdjustementOfResourceEnvironment();
+	resEnv->map relativeAdjustmentOfResourceEnvironment();
+//	resEnv->stepAdjustmentOfResourceEnvironment();
+
+	rep->map mapRepository();
+	allocation->map adjustAllocationBottomUp();
+	system->map adjustSystemBottomUp();
+}
+
+mapping ResourceEnvironment::absoluteAdjustementOfResourceEnvironment() : ResourceEnvironment
+when { spd.objects()[SPD]->any(true).scalingPolicies->any(true).adjustmentType.oclIsTypeOf(AbsoluteAdjustment) }
+{
+	init {
+		var adjustment : AbsoluteAdjustment := spd.objects()[SPD]->any(true).scalingPolicies->any(true).adjustmentType.oclAsType(AbsoluteAdjustment);
+		var nameOfResourceEnvironment := self.entityName;
+		var linkingResource := self.linkingResources__ResourceEnvironment;
+		var resourceContainers : Set(ResourceContainer) := AdjustResourceEnvironmentAbsolutely(adjustment,self);
+	 	
+	 	var myLinkingResource := object LinkingResource {};
+	 	myLinkingResource.connectedResourceContainers_LinkingResource += resourceContainers;
+	}
+	population {
+		object result : ResourceEnvironment { 
+			entityName := nameOfResourceEnvironment; 
+			linkingResources__ResourceEnvironment += myLinkingResource;
+			resourceContainer_ResourceEnvironment := resourceContainers;
+		};
+	}
+
+	end {
+	}
+}
+
+mapping ResourceEnvironment::relativeAdjustmentOfResourceEnvironment() : ResourceEnvironment 
+when { spd.objects()[SPD]->any(true).scalingPolicies->any(true).adjustmentType.oclIsTypeOf(RelativeAdjustment) }
+{	
+	init {
+		var adjustment : RelativeAdjustment := spd.objects()[SPD]->any(true).scalingPolicies->any(true).adjustmentType.oclAsType(RelativeAdjustment);
+		var nameOfResourceEnvironment := self.entityName;
+		var linkingResource := self.linkingResources__ResourceEnvironment;
+		var resourceContainers : Set(ResourceContainer) := AdjustResourceEnvironmentRelatively(adjustment,self);
+	 	
+	 	var myLinkingResource := object LinkingResource {};
+	 	myLinkingResource.connectedResourceContainers_LinkingResource += resourceContainers;
+	}
+
+	object result:ResourceEnvironment { 
+		entityName := nameOfResourceEnvironment; 
+		linkingResources__ResourceEnvironment += myLinkingResource;
+		resourceContainer_ResourceEnvironment := resourceContainers;
+	};
+
+	end{	
+	}
+}
+
+mapping Allocation::adjustAllocationBottomUp():Allocation{
+	
+	
+	object result:Allocation {
+		entityName := self.entityName;
+		allocationContexts_Allocation += self.allocationContexts_Allocation;	
+	}
+}
+
+
+/**
+* Semantic of replicating assemblies and connectors
+*
+*/
+mapping System::adjustSystemBottomUp():System {
+	
+	var resourceEnv := resolveone(ResourceEnvironment);
+	var originalResourceEnv := pcmResourceEnvironment.objects()[ResourceEnvironment]->any(true);
+	// newAssemblies are for a single target group (referenced assembly ctx)
+	var newAssemblies : Set(AssemblyContext) := Set{};
+	if (originalResourceEnv->size()=1){
+		resourceEnv.resourceContainer_ResourceEnvironment->forEach(resContainer){
+			if(resContainer.entityName!='aName'){ 
+			//TODO:: distinguish with annotations
+				self.assemblyContexts__ComposedStructure->forEach(assembly){				
+					newAssemblies += assembly->map replicateAssemblyToResourceContainer(resContainer);
+				}
+			}
+		}
+		
+	};
+	var baseAssembly : AssemblyContext := self.assemblyContexts__ComposedStructure->any(true);
+	var totalAssemblies: OrderedSet(AssemblyContext) := newAssemblies->union(self.assemblyContexts__ComposedStructure)->asOrderedSet();
+	// the base assembly has to be stored for each group 
+	// connectLoadBalancerAndAssemblyContexts(newAssemblies->any(true), loadBalancingAssemblies, newAssemblies->asOrderedSet());
+	var loadBalancerComponent : RepositoryComponent := new BasicComponent(baseAssembly.encapsulatedComponent__AssemblyContext, totalAssemblies->size());
+	var loadBalancerAssemblyContext : AssemblyContext := new AssemblyContext(loadBalancerComponent);
+	
+	object result:System {
+		entityName := self.entityName;
+		assemblyContexts__ComposedStructure	+= self.assemblyContexts__ComposedStructure;
+		assemblyContexts__ComposedStructure	+= newAssemblies;
+		assemblyContexts__ComposedStructure	+= loadBalancerAssemblyContext;
+		connectors__ComposedStructure := self.connectors__ComposedStructure->map mapConnectors();
+		providedRoles_InterfaceProvidingEntity := self.providedRoles_InterfaceProvidingEntity;
+		requiredRoles_InterfaceRequiringEntity := self.requiredRoles_InterfaceRequiringEntity;
+	};
+	
+	if (originalResourceEnv->size()=1){
+		resourceEnv.resourceContainer_ResourceEnvironment->forEach(resContainer){
+			if(resContainer.entityName!='aName'){ 
+			//TODO:: distinguish with annotations
+				self.assemblyContexts__ComposedStructure->forEach(assembly){				
+					newAssemblies += assembly->map replicateAssemblyToResourceContainer(resContainer);
+				}
+			}
+		}
+		
+	};
+	// additional connectors and modifications after system creation
+//	connectExistingLoadBalancerAndAssemblyContexts(baseAssembly, loadBalancerAssemblyContext, totalAssemblies);
+}
+
+mapping Repository::mapRepository():Repository {
+	init{
+		var repository := self.deepclone();
+		result := repository;
+	}
+}
+//
+//helper loadBalanceReplicas(assemblies:Set(AssemblyContext), baseAssembly:AssemblyContext):AssemblyContext{
+//	// 1. Construction: a load balancing component 
+//	var system := resolveone(System);
+//	// 1.1. with one (in case the component has one single) operation provided role matching the interface
+//	
+//	
+//	
+//	return loadBalancerAssemblyContext;
+//	// 1.2. create operation required roles one for each replica with matching interface 
+//	// 1.3. creaete SEFF that probabilistically load balances inbetween
+//	// 1.4. add the component to the repository
+//	
+//	// 2. Wiring
+//	
+//	// 2.1. map all delegetion connectors to the new load balancing component 
+//	// 2.3. create assembly connectors that connect operation required roles with operation provided roles
+//	 
+//		 
+//}
+
+mapping Connector::mapConnectors() : Connector {
+	init {
+		result := self;
+	}
+}
+mapping ProvidedDelegationConnector::mapConnectors() : ProvidedDelegationConnector {
+	init { 
+		result := self;
+	}
+}
+
+mapping AssemblyContext::replicateAssemblyToResourceContainer(resourceContainer: ResourceContainer) : AssemblyContext{
+	init{
+		var entityName := self.entityName;
+		var encapsulatedComponent := self.encapsulatedComponent__AssemblyContext;
+		var configParameters := self.configParameterUsages__AssemblyContext;
+		var system := resolveone(System);
+		var allocation := resolveone(Allocation);
+		log('resource container name '+resourceContainer.entityName);
+		result := Commons_createAssemblyContext(encapsulatedComponent, self, system, allocation, resourceContainer);
+	}
+};
+
+/**
+* Semantic of adjusting relatively an ElasticInfrastructure TargetGroup
+* 
+* @param adjustment 	The RelativeAdjustment definition from SPD.
+*/
+helper AdjustResourceEnvironmentRelatively(adjustment: RelativeAdjustment, resourceEnv: ResourceEnvironment) : Set(ResourceContainer) {
+	var minAdjustmentValue : Integer := adjustment.minAdjustmentValue;
+	var percentageGrowthValue : Real := adjustment.percentageGrowthValue;
+	var newResourceContainers : Set(ResourceContainer) := Set{};
+	log('A relative adjustment has been specified with min value: '+minAdjustmentValue.toString()+', and percentage growth '+percentageGrowthValue.toString());
+	
+	var numberOfResourceContainers : Integer = resourceEnv.resourceContainer_ResourceEnvironment->size();
+	
+	log('Current number of containers ' + numberOfResourceContainers.toString());
+	
+	switch {
+		case (numberOfResourceContainers*percentageGrowthValue < minAdjustmentValue){
+			var i : Integer := 0;
+			while (i < minAdjustmentValue) {			
+				var resourceContainer := Helper_createResourceContainerInHomogeneousEnvironment(resourceEnv.resourceContainer_ResourceEnvironment->any(true));
+				newResourceContainers += resourceContainer;
+				i := i + 1;
+			}					
+		}
+	};
+	
+	resourceEnv.resourceContainer_ResourceEnvironment->forEach(rC) {
+		var resourceContainer := CopyResourceContainer(rC);
+		newResourceContainers += resourceContainer;	
+	};
+	
+	return newResourceContainers;
+}
+
+/**
+* Semantic of adjusting relatively an ElasticInfrastructure TargetGroup
+* 
+* @param adjustment 	The RelativeAdjustment definition from SPD.
+*/
+helper AdjustResourceEnvironmentAbsolutely(adjustment: AbsoluteAdjustment, resourceEnv: ResourceEnvironment) : Set(ResourceContainer) {
+	var goalValue := adjustment.goalValue;
+	var newResourceContainers : Set(ResourceContainer) := Set{};
+	
+	log('An absolute adjustment has been specified with goal value: '+ goalValue.toString());
+	
+	var numberOfResourceContainers : Integer = resourceEnv.resourceContainer_ResourceEnvironment->size();
+	
+	switch {
+		case (numberOfResourceContainers < goalValue){
+			var i : Integer := 0;
+			while (i < goalValue - numberOfResourceContainers) {			
+				var resourceContainer := Helper_createResourceContainerInHomogeneousEnvironment(resourceEnv.resourceContainer_ResourceEnvironment->any(true));
+				newResourceContainers += resourceContainer;
+				i := i + 1;
+			}					
+		}
+		case (numberOfResourceContainers > goalValue){
+			log("implementation missing");
+		}
+	};
+	
+	resourceEnv.resourceContainer_ResourceEnvironment->forEach(rC) {
+		var resourceContainer := CopyResourceContainer(rC);
+		newResourceContainers += resourceContainer;	
+	};
+	
+	return newResourceContainers;
+}
+
+
+/**
+ * Create a resource container, add it to the environment and linking resource
+ *
+
+ * Wrapper to the more detailed createAssemblyContext method
+ *
+ * @param resEnv	 					The Resource Environment that referenced in a target group.
+ * @param templateResourceContainer		The template resource container from which the processing specification is copied.
+ */
+helper Helper_createResourceContainerInHomogeneousEnvironment(templateResourceContainer : ResourceContainer) : ResourceContainer {
+	
+	// duplicate resource container with same active resource specification
+	var newResContainer := object ResourceContainer {
+		entityName := templateResourceContainer.entityName+Commons_getUniqueElementNameSuffix();
+	};
+	var processingRate := object PCMRandomVariable {
+		specification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.processingRate_ProcessingResourceSpecification->any(true).specification;
+	};
+	
+	var newResourceSpec := object ProcessingResourceSpecification {
+		activeResourceType_ActiveResourceSpecification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification->any(true);
+		processingRate_ProcessingResourceSpecification := processingRate;
+		schedulingPolicy := templateResourceContainer.activeResourceSpecifications_ResourceContainer.schedulingPolicy->any(true);
+	};
+	newResContainer.activeResourceSpecifications_ResourceContainer += newResourceSpec;
+	return newResContainer;
+}
+
+
+helper CopyResourceContainer(current: ResourceContainer) : ResourceContainer {
+	var processingRate := object PCMRandomVariable {
+		specification := current.activeResourceSpecifications_ResourceContainer.processingRate_ProcessingResourceSpecification->any(true).specification;
+	};
+	var newResourceSpec := object ProcessingResourceSpecification {
+		activeResourceType_ActiveResourceSpecification := current.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification->any(true);
+		processingRate_ProcessingResourceSpecification := processingRate;
+		schedulingPolicy := current.activeResourceSpecifications_ResourceContainer.schedulingPolicy->any(true);
+	};
+	return object ResourceContainer {
+		id := current.id;
+		entityName := current.entityName;
+		activeResourceSpecifications_ResourceContainer += newResourceSpec;
+	}
+}
+
+
+/**
+* Adapted from Loadbalancing.qvto from ATs to enable load balancing of newly created assemblies 
+*
+*/

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Commons.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Commons.qvto
@@ -1,0 +1,360 @@
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_USAGE uses 'http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2';
+modeltype PCM_FEATURE_CONF uses 'http://sdq.ipd.uka.de/FeatureConfig/2.0';
+modeltype PCM_FEATURE_MOD uses 'http://sdq.ipd.uka.de/FeatureModel/2.0';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+modeltype PCM_STOEX uses 'http://sdq.ipd.uka.de/StochasticExpressions/2.2';
+
+/**
+ * Library with utilities to find elements.
+ *
+ * @author Benjamin Klatt
+ */
+library Commons();
+
+/** Counter to ensure individual element names */
+property commonsElementCounter : Integer = 0;
+
+/** Counter to ensure individual element names */
+property counter : Integer = 0;
+
+/** 
+ * Get an element suffix id to prevent duplicate element names.
+ * @return An unique string that can be used as unique name suffix.
+ */
+helper Commons_getUniqueElementNameSuffix() : String {
+	commonsElementCounter := commonsElementCounter + 1;
+	return ("_" + commonsElementCounter.toString());
+}
+
+/** 
+ * Get an element suffix id to prevent duplicate element names.
+ * @return An unique string that can be used as unique name suffix.
+ */
+helper Commons_getValue() : String {
+	counter := counter + 1;
+	return (counter.toString());
+}
+
+/**
+ * Create the assembly context in allignment to an existing assembly context.
+ *
+ * Wrapper to the more detailed createAssemblyContext method
+ *
+ * @param component 		The repository component to assembly.
+ * @param templateContext	The assembly context to be used as template.
+ * @param system			The system to add the assembly to.
+ * @param allocation		The allocation this context should belong to.
+ * @param resourceContainer	The resource container to deploy on.
+ * @return The new assembly context for the component
+ */
+helper Commons_createAssemblyContext(	component : RepositoryComponent , 
+										templateContext : AssemblyContext,
+										inout system : System,
+										allocation : Allocation,
+										resourceContainer : ResourceContainer) : AssemblyContext {
+	
+	var assemblyContext := Commons_createAssemblyContext(	component,
+									templateContext.parentStructure__AssemblyContext,
+									templateContext.configParameterUsages__AssemblyContext,
+									system,
+									allocation,
+									resourceContainer);
+											
+	return assemblyContext;
+}
+
+/**
+ * Create an assembly context. 
+ *
+ * Based on the uniqueContext, this mapping ensures that a 
+ * component can be deployed multiple times with the same parameters
+ * but only once per uniqueContext.
+ *
+ * The aligned helper is used internally.
+ * 
+ *
+ * @param component 			The repository component to assembly.
+ * @param parentStructure		The the parent structure of the assembly context.
+ * @param componentVariables	The component configuration variables.
+ * @param system				The system to add the assembly to.
+ * @param allocation			The allocation this context should belong to.
+ * @param resourceContainer		The resource container to deploy on.
+ * @return The new assembly context for the component
+ */
+mapping Commons_createAssemblyContext(	uniqueContext : AssemblyContext,
+										component : RepositoryComponent , 
+										parentStructure : ComposedStructure,
+										componentVariables : Set(VariableUsage), 
+										inout system : System,
+										allocation : Allocation,
+										resourceContainer : ResourceContainer) : AssemblyContext {
+	
+	init {
+		log('deployed component for context ', uniqueContext);
+	}
+	
+	entityName := component.entityName+'_AssemblyContext'+Commons_getUniqueElementNameSuffix();
+	encapsulatedComponent__AssemblyContext := component;
+	parentStructure__AssemblyContext := parentStructure;
+	configParameterUsages__AssemblyContext := componentVariables;
+	
+	end {
+		// link the assembly context in the system
+		system.assemblyContexts__ComposedStructure += result;
+		
+		// allocate the assembly	
+		Commons_createAllocationContext(	result,
+											allocation,
+											resourceContainer);
+	}
+}
+/**
+ * Create the assembly context for a component. 
+ *
+ * While this is a helper, it is possibel to instantiate a component multiple times
+ * with the same parameters.
+ *
+ * @param component 			The repository component to assembly.
+ * @param parentStructure		The the parent structure of the assembly context.
+ * @param componentVariables	The component configuration variables.
+ * @param system				The system to add the assembly to.
+ * @param allocation			The allocation this context should belong to.
+ * @param resourceContainer		The resource container to deploy on.
+ * @return The new assembly context for the component
+ */
+helper Commons_createAssemblyContext(	component : RepositoryComponent , 
+										parentStructure : ComposedStructure,
+										componentVariables : Set(VariableUsage), 
+										inout system : System,
+										allocation : Allocation,
+										resourceContainer : ResourceContainer) : AssemblyContext {
+	
+	var assemblyContext := object AssemblyContext {
+		entityName := component.entityName+'_AssemblyContext'+Commons_getUniqueElementNameSuffix();
+		encapsulatedComponent__AssemblyContext := component;
+		parentStructure__AssemblyContext := parentStructure;
+		configParameterUsages__AssemblyContext := componentVariables;
+	};
+
+	// link the assembly context in the system
+	system.assemblyContexts__ComposedStructure += assemblyContext;
+	
+	// allocate the assembly	
+	Commons_createAllocationContext(	assemblyContext,
+											allocation,
+											resourceContainer);
+											
+	return assemblyContext;
+}
+
+
+
+/**
+ * Create the assembly and allocation context for the SourcePortComponent
+ * and the assembly connector between the source and the source port.
+ *
+ * @param connectorName	The name of the new connector
+ * @param providedRole	The provided role to connect
+ * @param requiredRole 	The required role to connect
+ * @return The prepared assembly connector
+ */
+helper Commons_deployAndConnect(	providedRole : OperationProvidedRole,
+									requiredRole : OperationRequiredRole,
+									fromAssemblyContext: AssemblyContext,
+									inout system : System,
+									allocation : Allocation,
+									resourceContainer : ResourceContainer) : AssemblyConnector {
+	
+		// get the source port component to be connected
+		var component := providedRole.providingEntity_ProvidedRole[RepositoryComponent]->any(true);
+		
+		// create the source port assembly context
+		var toAssemblyContext := Commons_createAssemblyContext(	component, 
+																fromAssemblyContext, 
+																system,
+																allocation,
+																resourceContainer);
+									
+	// create the connector
+	var  assemblyConnector := Commons_connect(	fromAssemblyContext,
+												toAssemblyContext,
+												providedRole, 
+												requiredRole);
+	
+	// assign the coonector to the system when it is prepared
+	system.connectors__ComposedStructure += assemblyConnector;
+	
+	return assemblyConnector;
+}
+
+/**
+ * Create the assembly connector between two assembly respectivly their roles.
+ *
+ * @param fromAssemblyContext	The from context.
+ * @param toAssemblyContext		The to context.
+ * @param providedRole			The provided role.
+ * @param requiredRole			The required role.
+ * @return The resulting connector.
+ */
+helper Commons_connect(	fromAssemblyContext: AssemblyContext,
+						toAssemblyContext: AssemblyContext,
+						providedRole : OperationProvidedRole,
+						requiredRole : OperationRequiredRole) : AssemblyConnector {
+		// create the connector
+	var  assemblyConnector := object AssemblyConnector {
+		entityName := 'AssemblyConnector_'+fromAssemblyContext.entityName+'_to_'+providedRole.providingEntity_ProvidedRole.entityName+Commons_getUniqueElementNameSuffix();
+		requiringAssemblyContext_AssemblyConnector := fromAssemblyContext;
+		providingAssemblyContext_AssemblyConnector := toAssemblyContext;
+		providedRole_AssemblyConnector := providedRole;
+		requiredRole_AssemblyConnector := requiredRole;
+		parentStructure__Connector := fromAssemblyContext.parentStructure__AssemblyContext;
+	};
+	return assemblyConnector;
+}
+
+/**
+ * Create the new allocation context for an assembly.
+ * The context is build according to an existing template assembly context.
+ * @param assemblyToAllocate The Assembly Context to be allocated
+ * @param allocation The allocation to add the new context to
+ * @param resourceContainer The resource container the assembly should be deployed on
+ * @return The newly created allocation context.
+ */
+helper Commons_createAllocationContext(	assemblyToAllocate : AssemblyContext, 
+										allocation : Allocation,
+										resourceContainer : ResourceContainer) : AllocationContext {
+	
+	var allocationContext := object AllocationContext {
+		entityName := 'AssemblyContext_'+assemblyToAllocate.entityName;
+		assemblyContext_AllocationContext := assemblyToAllocate;
+		allocation_AllocationContext := allocation;
+		resourceContainer_AllocationContext := resourceContainer;
+	};
+	
+	return allocationContext;
+}
+
+/**
+ * Create a basic component
+ * 
+ * @param name 			The name of the component
+ * @param repository 	The repository to assign this component to
+ * @return the prepared component
+ */
+helper Commons_createBasicComponent ( 	name : String,
+										repository : Repository ) : BasicComponent {				
+	var component := object BasicComponent {	
+		entityName := name;
+		repository__RepositoryComponent := repository;
+	};
+	return component;
+}
+
+/**
+ * Create the OperationRequiredRole between an operation interface and a requiring entity
+ * @param interface 		The operation interface to reference to
+ * @param requiringEntity 	The requiring entity
+ */
+mapping Commons_createOperationRequiredRole(interface : OperationInterface,
+											sourceRole : SourceRole) : OperationRequiredRole {
+	// build the operation required role
+	// var role := object OperationRequiredRole {
+		entityName := 'SourceRole'+sourceRole.entityName;
+		requiredInterface__OperationRequiredRole := interface;
+		requiringEntity_RequiredRole := sourceRole.requiringEntity_RequiredRole;
+	// };
+	//return role;
+}
+
+/**
+ * Create the OperationRequiredRole between an operation interface and a requiring entity
+ * @param interface 		The operation interface to reference to
+ * @param requiringEntity 	The requiring entity
+ */
+helper Commons_createOperationRequiredRole(	name : String,
+											entity : InterfaceRequiringEntity, 
+											interface : OperationInterface) : OperationRequiredRole {
+	// build the operation required role
+	var role := object OperationRequiredRole {
+		entityName := name;
+		requiredInterface__OperationRequiredRole := interface;
+		requiringEntity_RequiredRole := entity;
+	};
+	return role;
+}
+
+
+/**
+ * Create the operation providing role for a source port
+ * @param component The providing compoenent
+ * @param interface The provided interface
+ * @return The prepared operation provided role
+ */
+helper Commons_createOperationProvidedRole(	name : String,
+											entity : InterfaceProvidingEntity , 
+											interface : OperationInterface) : OperationProvidedRole {
+	var role := object OperationProvidedRole {										
+		entityName := name;
+		providedInterface__OperationProvidedRole := interface;
+		providingEntity_ProvidedRole := entity;
+	};
+	return role;
+}
+
+/**
+ * Get an operation required role of a component encapsulated by an assembly
+ * context that references a specific operation interface.
+ *
+ * @param assemblyContext	The context to get the component from
+ * @param interface			The operation interface that must be referenced
+ * @return the found role
+ */
+query Commons_getOperationRequiredRole(	assemblyContext : AssemblyContext, 
+										interface : OperationInterface) : OperationRequiredRole {
+		var operationRequiredRole := assemblyContext
+					.encapsulatedComponent__AssemblyContext
+					.requiredRoles_InterfaceRequiringEntity
+					->select(rr|rr.oclIsTypeOf(OperationRequiredRole))
+					->oclAsType(OperationRequiredRole)
+					->select(opr|opr.requiredInterface__OperationRequiredRole = interface)
+					->any(true);
+					
+		return operationRequiredRole;
+}
+
+/**
+ * Get the providing component for an operation providing role
+ * @param role The provided role.
+ * @return The providing component.
+ */
+query Commons_getProvidingComponent(role : ProvidedRole) : RepositoryComponent {
+	return role.providingEntity_ProvidedRole
+				->oclAsType(RepositoryComponent)
+				->any(true);
+}
+
+/**
+ * Get a list of variable characterisation types someone could iterate over.
+ * @return The set of availabel characterization types
+ */
+query Commons_getListOfVariableCharacterisationTypes() : Set(VariableCharacterisationType) {
+	
+	var types : Set(VariableCharacterisationType) = Set{};
+	
+	types+= VariableCharacterisationType::STRUCTURE;
+	types+= VariableCharacterisationType::NUMBER_OF_ELEMENTS;
+	types+= VariableCharacterisationType::VALUE;
+	types+= VariableCharacterisationType::BYTESIZE;
+	types+= VariableCharacterisationType::TYPE;
+	
+	return types;
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Constructors.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Constructors.qvto
@@ -1,0 +1,300 @@
+import org.palladiosimulator.architecturaltemplates.catalog.black.ProfilesLibrary;
+
+modeltype ECORE uses 'http://www.eclipse.org/emf/2002/Ecore';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCMComposition uses pcm::core::composition('http://palladiosimulator.org/PalladioComponentModel/5.2');
+modeltype PCMSEFF uses pcm::seff('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCMSEFF_PERFORMANCE uses pcm::seff::seff_performance('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCM_RESOURCETYPE uses pcm::resourcetype('http://palladiosimulator.org/PalladioComponentModel/5.2');
+
+library Constructors();
+
+
+constructor RequiredDelegationConnector :: RequiredDelegationConnector(assemblyContext : AssemblyContext, innerRequiredRole : OperationRequiredRole, outerRequiredRole : OperationRequiredRole){
+	var system : System := resolveone(System);
+	entityName := "RequiredDelegation " + innerRequiredRole.entityName + "_" + outerRequiredRole.entityName;
+	assemblyContext_RequiredDelegationConnector := assemblyContext;
+	innerRequiredRole_RequiredDelegationConnector := innerRequiredRole;
+	outerRequiredRole_RequiredDelegationConnector := outerRequiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor RequiredInfrastructureDelegationConnector :: RequiredInfrastructureDelegationConnector(assemblyContext : AssemblyContext, innerRequiredRole : InfrastructureRequiredRole, outerRequiredRole : InfrastructureRequiredRole){
+	var system : System :=  assemblyContext.parentStructure__AssemblyContext[System]->any(true);
+
+	entityName := "RequiredDelegation " + innerRequiredRole.entityName + "_" + outerRequiredRole.entityName;
+	assemblyContext__RequiredInfrastructureDelegationConnector := assemblyContext;
+	innerRequiredRole__RequiredInfrastructureDelegationConnector := innerRequiredRole;
+	outerRequiredRole__RequiredInfrastructureDelegationConnector := outerRequiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor AssemblyConnector :: AssemblyConnector(requiringAssemblyContext : AssemblyContext,requiredRole:OperationRequiredRole, providedRole: OperationProvidedRole, providingAssemblyContext : AssemblyContext){
+	var system : System :=  requiringAssemblyContext.parentStructure__AssemblyContext[System]->any(true);
+	entityName := requiringAssemblyContext.entityName + "_" + providingAssemblyContext.entityName;
+	providingAssemblyContext_AssemblyConnector := providingAssemblyContext;
+	requiringAssemblyContext_AssemblyConnector := requiringAssemblyContext;
+	providedRole_AssemblyConnector := providedRole;
+	requiredRole_AssemblyConnector := requiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor AssemblyInfrastructureConnector :: AssemblyInfrastructureConnector(requiringAssemblyContext : AssemblyContext,requiredRole:InfrastructureRequiredRole, providedRole: InfrastructureProvidedRole, providingAssemblyContext : AssemblyContext){
+	var system : System :=  requiringAssemblyContext.parentStructure__AssemblyContext[System]->any(true);
+	entityName := requiringAssemblyContext.entityName + "_" + providingAssemblyContext.entityName;
+	providingAssemblyContext__AssemblyInfrastructureConnector := providingAssemblyContext;
+	requiringAssemblyContext__AssemblyInfrastructureConnector := requiringAssemblyContext;
+	providedRole__AssemblyInfrastructureConnector := providedRole;
+	requiredRole__AssemblyInfrastructureConnector := requiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor LinkingResource :: LinkingResource (resourceContainer : ResourceContainer, latency : String, throughput : String){
+	connectedResourceContainers_LinkingResource := resourceContainer;
+	resourceEnvironment_LinkingResource := resourceContainer.resourceEnvironment_ResourceContainer;
+	communicationLinkResourceSpecifications_LinkingResource := new CommunicationLinkResourceSpecification(resourceContainer,latency,throughput);
+}
+
+constructor CommunicationLinkResourceSpecification :: CommunicationLinkResourceSpecification(resourceContainer : ResourceContainer, latency : String, throughput : String){
+	latency_CommunicationLinkResourceSpecification := new PCMRandomVariable(latency);
+	throughput_CommunicationLinkResourceSpecification := new PCMRandomVariable(throughput);
+	communicationLinkResourceType_CommunicationLinkResourceSpecification := resourceContainer.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification.resourceRepository_ResourceType.availableResourceTypes_ResourceRepository->selectByType(CommunicationLinkResourceType)->selectOne(resourceType : ResourceType |resourceType.id = "_o3sScH2AEdyH8uerKnHYug");
+}
+
+constructor AllocationContext :: AllocationContext (ac : AssemblyContext, rc: ResourceContainer){
+	var allocation : Allocation := resolveone(Allocation);
+	entityName := "Allocation_" + ac.entityName;
+	assemblyContext_AllocationContext := ac;
+	resourceContainer_AllocationContext := rc;
+	allocation_AllocationContext := allocation;
+}
+
+constructor ProcessingResourceSpecification:: ProcessingResourceSpecification(p:ProcessingResourceSpecification, rc : ResourceContainer){
+	MTTF := p.MTTF;
+	MTTR := p.MTTR;
+	schedulingPolicy := p.schedulingPolicy;
+	requiredByContainer := p.requiredByContainer;
+	processingRate_ProcessingResourceSpecification := new PCMRandomVariable(p.processingRate_ProcessingResourceSpecification);
+	numberOfReplicas := p.numberOfReplicas;
+	activeResourceType_ActiveResourceSpecification := p.activeResourceType_ActiveResourceSpecification;
+	resourceContainer_ProcessingResourceSpecification := rc;
+}
+
+/**Creates a PCMRandomVariable from an existing PCMRandomVariable
+*/
+constructor PCMRandomVariable :: PCMRandomVariable(pcmRandomVariable:PCMRandomVariable){
+	specification := pcmRandomVariable.specification;
+}
+
+/**Creates a PCMRandomVariable with a specified input parameter
+*/
+constructor PCMRandomVariable :: PCMRandomVariable(spec:String){
+	specification := spec;
+}
+
+constructor ResourceContainer :: ResourceContainer(originalResourceContainer : ResourceContainer, rcName : String){
+	entityName := originalResourceContainer.entityName + rcName;
+	resourceEnvironment_ResourceContainer := originalResourceContainer.resourceEnvironment_ResourceContainer;
+	
+	if(originalResourceContainer.nestedResourceContainers__ResourceContainer->size()>0)	{
+		nestedResourceContainers__ResourceContainer := originalResourceContainer.duplicateNestedResourceContainer();
+	};
+	
+	activeResourceSpecifications_ResourceContainer += originalResourceContainer.activeResourceSpecifications_ResourceContainer -> forEach(activeResource){
+		new ProcessingResourceSpecification(activeResource, result);
+	};
+} 
+
+helper ResourceContainer::duplicateNestedResourceContainer():Set(ResourceContainer){
+	var nestedResourceContainer : Set(ResourceContainer);
+	self.nestedResourceContainers__ResourceContainer->forEach(rc){
+		nestedResourceContainer += new ResourceContainer(rc, rc.entityName);	
+	};
+
+	return nestedResourceContainer;
+}
+
+constructor AssemblyContext :: AssemblyContext(bc : RepositoryComponent) {
+	entityName := "Assembly_"+bc.entityName;
+	encapsulatedComponent__AssemblyContext := bc;
+	var allocation : Allocation := resolveone(Allocation);
+	var system : System := allocation.system_Allocation![System];
+	parentStructure__AssemblyContext := system;
+}
+
+constructor BasicComponent :: BasicComponent (loadBalancedComponent : RepositoryComponent, numberOfReplicas: Integer)
+{
+	var repository := resolveone(Repository);
+	var providedRoles : Set(ProvidedRole) := loadBalancedComponent.providedRoles_InterfaceProvidingEntity;
+	entityName := "LoadBalancer_"+ loadBalancedComponent.entityName;
+	log(entityName);
+	repository__RepositoryComponent := repository;
+	log('size of provided roles '+providedRoles->size().toString());
+	providedRoles -> forEach(providedRole){
+		if(providedRole.oclIsTypeOf(OperationProvidedRole)){
+			var counter : Integer := 1;
+			providedRoles_InterfaceProvidingEntity += new OperationProvidedRole(providedRole.oclAsType(OperationProvidedRole));
+			while(counter<= (numberOfReplicas)){
+			log('operation required roles+replicas:'+numberOfReplicas.toString());
+				requiredRoles_InterfaceRequiringEntity += new OperationRequiredRole(providedRole.oclAsType(OperationProvidedRole),counter);
+				counter := counter+1;
+			};
+		}else if(providedRole.oclIsTypeOf(InfrastructureProvidedRole)){
+			var counter : Integer := 1;
+			providedRoles_InterfaceProvidingEntity += new InfrastructureProvidedRole(providedRole.oclAsType(InfrastructureProvidedRole));
+			while(counter<= (numberOfReplicas)){
+				requiredRoles_InterfaceRequiringEntity += new InfrastructureRequiredRole(providedRole.oclAsType(InfrastructureProvidedRole),counter);
+				counter := counter+1;
+			};
+		};
+	};
+	
+	componentParameterUsage_ImplementationComponentType := loadBalancedComponent[ImplementationComponentType].componentParameterUsage_ImplementationComponentType;
+	
+	providedRoles_InterfaceProvidingEntity -> forEach(providedRole){
+	if(providedRole.oclIsTypeOf(OperationProvidedRole)){
+		var operationProvidedRole := providedRole.oclAsType(OperationProvidedRole);
+		var operationInterface := operationProvidedRole.providedInterface__OperationProvidedRole;
+		var operationRequiredRoles : Set(OperationRequiredRole) := requiredRoles_InterfaceRequiringEntity ->selectByType(OperationRequiredRole);
+		var requiredRolesWithSameInterfaceAsProvidedRole : Set(OperationRequiredRole) := operationRequiredRoles -> select(operationRequiredRole : OperationRequiredRole | operationRequiredRole.requiredInterface__OperationRequiredRole.id = operationInterface.id);
+		operationInterface.signatures__OperationInterface->forEach(operationSignature){
+	  		serviceEffectSpecifications__BasicComponent += new ResourceDemandingSEFF(operationSignature, requiredRolesWithSameInterfaceAsProvidedRole);
+		};
+		}else if(providedRole.oclIsTypeOf(InfrastructureProvidedRole)){
+			var infrastructureProvidedRole := providedRole.oclAsType(InfrastructureProvidedRole);
+			var infrastructureInterface := infrastructureProvidedRole.providedInterface__InfrastructureProvidedRole;
+			var infrastructureRequiredRoles : Set(InfrastructureRequiredRole) := requiredRoles_InterfaceRequiringEntity ->selectByType(InfrastructureRequiredRole);
+			var requiredRolesWithSameInterfaceAsProvidedRole : Set(InfrastructureRequiredRole) := infrastructureRequiredRoles -> select(infrastructureRequiredRole : InfrastructureRequiredRole | infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id = infrastructureInterface.id);
+			infrastructureInterface.infrastructureSignatures__InfrastructureInterface->forEach(infrastructureSignature){
+  				serviceEffectSpecifications__BasicComponent += new ResourceDemandingSEFF(infrastructureSignature, requiredRoles_InterfaceRequiringEntity[InfrastructureRequiredRole]);
+	};
+		};
+	}
+}
+
+constructor ProbabilisticBranchTransition :: ProbabilisticBranchTransition (operationSignature:OperationSignature, reqRole:OperationRequiredRole) {
+	entityName := "Branch for "+ reqRole.entityName;
+	branchProbability := 1.0;
+    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+    	var innerStartAction : StartAction := object StartAction{};
+    	var delegatingExternalCallAction : ExternalCallAction := object ExternalCallAction{
+    		predecessor_AbstractAction := innerStartAction;
+    		entityName := "Call "+ operationSignature.entityName;
+    		role_ExternalService := reqRole;
+    		calledService_ExternalService := operationSignature;
+    	};
+    	var innerStopAction : StopAction := object StopAction{
+			predecessor_AbstractAction := delegatingExternalCallAction;
+		};
+		
+		steps_Behaviour += innerStartAction;
+		steps_Behaviour += delegatingExternalCallAction;
+		steps_Behaviour += innerStopAction;
+    };
+}
+
+constructor ResourceDemandingSEFF :: ResourceDemandingSEFF (operationSignature : OperationSignature, requiredRoles : Set(OperationRequiredRole)){
+	describedService__SEFF := operationSignature;
+	var startAction : StartAction := object StartAction{};
+	var branchAction : BranchAction := object BranchAction{
+		entityName := "LoadBalancer Branch";
+		predecessor_AbstractAction := startAction;
+		
+		requiredRoles->forEach(requiredRole){
+		    var probability : Real := 1.0 / requiredRoles->size();
+			branches_Branch += object ProbabilisticBranchTransition{
+			    entityName := "Branch for "+requiredRole.entityName;
+			    branchProbability := probability;
+			    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+			    	var innerStartAction : StartAction := object StartAction{};
+			    	var delegatingExternalCallAction : ExternalCallAction := object ExternalCallAction{
+			    		predecessor_AbstractAction := innerStartAction;
+			    		entityName := "Call "+operationSignature.entityName;
+			    		role_ExternalService := requiredRole;
+			    		calledService_ExternalService := operationSignature;
+			    	};
+			    	var innerStopAction : StopAction := object StopAction{
+						predecessor_AbstractAction := delegatingExternalCallAction;
+					};
+					
+					steps_Behaviour += innerStartAction;
+					steps_Behaviour += delegatingExternalCallAction;
+					steps_Behaviour += innerStopAction;
+			    };
+			};
+		};
+	};
+	var stopAction : StopAction := object StopAction{
+		predecessor_AbstractAction := branchAction;
+	};
+	steps_Behaviour += startAction;
+	steps_Behaviour += branchAction;
+	steps_Behaviour += stopAction;
+}
+
+constructor ResourceDemandingSEFF::ResourceDemandingSEFF (infrastructureSignature : InfrastructureSignature, requiredRoles : Set(InfrastructureRequiredRole)){
+	describedService__SEFF := infrastructureSignature;
+	var startAction : StartAction := object StartAction{};
+	var branchAction : BranchAction := object BranchAction{
+		entityName := "LoadBalancer Branch";
+		predecessor_AbstractAction := startAction;
+		
+		requiredRoles->forEach(requiredRole){
+		    var probability : Real := 1.0 / requiredRoles->size();
+			branches_Branch += object ProbabilisticBranchTransition{
+			    entityName := "Branch for "+requiredRole.entityName;
+			    branchProbability := probability;
+			    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+			    	var innerStartAction : StartAction := object StartAction{};
+			    	var internalCallAction : InternalAction:= object InternalAction{
+			    		entityName := "Call "+infrastructureSignature.entityName;
+			    		predecessor_AbstractAction := innerStartAction;
+			    		infrastructureCall__Action := object InfrastructureCall{
+			    			entityName := "InfrastructureCall " + requiredRole.entityName;
+			    			signature__InfrastructureCall := infrastructureSignature;
+			    			requiredRole__InfrastructureCall := requiredRole;
+			    			numberOfCalls__InfrastructureCall := new PCMRandomVariable("1");
+			    		};
+			    	};
+			    	var innerStopAction : StopAction := object StopAction{
+						predecessor_AbstractAction := internalCallAction;
+					};
+					
+					steps_Behaviour += innerStartAction;
+					steps_Behaviour += internalCallAction;
+					steps_Behaviour += innerStopAction;
+			    };
+			};
+		};
+	};
+	var stopAction : StopAction := object StopAction{
+		predecessor_AbstractAction := branchAction;
+	};
+	steps_Behaviour += startAction;
+	steps_Behaviour += branchAction;
+	steps_Behaviour += stopAction;
+}	
+
+constructor OperationProvidedRole :: OperationProvidedRole(pr:OperationProvidedRole){
+	entityName := "Provided_" + pr.providedInterface__OperationProvidedRole.entityName + "_LoadBalancer";
+	providedInterface__OperationProvidedRole := pr.providedInterface__OperationProvidedRole;
+}
+
+constructor OperationRequiredRole :: OperationRequiredRole(rr:OperationProvidedRole, i:Integer){
+	entityName := "Required_" + rr.providedInterface__OperationProvidedRole.entityName +"_LoadBalancer_"+i.toString();
+	requiredInterface__OperationRequiredRole := rr.providedInterface__OperationProvidedRole;
+}
+
+constructor InfrastructureProvidedRole::InfrastructureProvidedRole(providedRole : InfrastructureProvidedRole){
+	entityName := "Provided_" + providedRole.providedInterface__InfrastructureProvidedRole.entityName + "_LoadBalancer";
+	providedInterface__InfrastructureProvidedRole := providedRole.providedInterface__InfrastructureProvidedRole;
+}
+
+constructor InfrastructureRequiredRole::InfrastructureRequiredRole(providedRole : InfrastructureProvidedRole, counter : Integer){
+	entityName := "Required_" + providedRole.providedInterface__InfrastructureProvidedRole.entityName +"_LoadBalancer_"+counter.toString();
+	requiredInterface__InfrastructureRequiredRole := providedRole.providedInterface__InfrastructureProvidedRole;
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Loadbalancing.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Loadbalancing.qvto
@@ -1,0 +1,692 @@
+import org.palladiosimulator.architecturaltemplates.catalog.black.ProfilesLibrary;
+
+modeltype ECORE uses 'http://www.eclipse.org/emf/2002/Ecore';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCMComposition uses pcm::core::composition('http://palladiosimulator.org/PalladioComponentModel/5.2');
+modeltype PCMSEFF uses pcm::seff('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCM_COMPLETION uses 'http://palladiosimulator.org/AnalyzerFramework/Completions/1.0';
+modeltype PCMSEFF_PERFORMANCE uses pcm::seff::seff_performance('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCM_RESOURCETYPE uses pcm::resourcetype('http://palladiosimulator.org/PalladioComponentModel/5.2');
+
+transformation Loadbalancing(inout pcmAllocation : PCM_ALLOC);
+
+//String constants of the Static Assembly Context Loadbalancing Profile					   			 
+property staticAssemblyContextLoadbalancingProfile : String = "StaticAssemblyContextLoadbalancingProfile";
+property staticAssemblyContextLoadbalancingSystemStereotype : String = "StaticAssemblyContextLoadbalancingSystem";
+property staticLoadbalancedAssemblyContextStereotype : String = "StaticLoadbalancedAssemblyContext";
+
+//String constants of the Dynamic Horizontal Scaling Assembly Context  Profile	
+property dynamicHorizontalScalingAssemblyContextProfile : String = "DynamicHorizontalScalingAssemblyContextProfile";
+property dynamicHorizontalScalingAssemblyContextSystemStereotype : String = "DynamicHorizontalScalingAssemblyContextSystem";
+property replicableAssemblyContextStereotype : String = "ReplicableAssemblyContext"; 
+
+//String constants of the Dynamic Horizontal Scaling Assembly Context  and Static Assembly Context Loadbalancing Profile	
+property numberOfReplicasTaggedValue : String = "numberOfReplicas";
+
+//String constants of the Loadbalanced Profile	
+property loadbalancedProfile : String = "LoadbalancedProfile";
+property originalAssemblyContextStereotype : String = "OriginalAssemblyContext";
+property loadbalancerAssemblyContextStereotype : String = "LoadbalancerAssemblyContext";
+property duplicateAssemblyContextStereotype : String = "DuplicateAssemblyContext";
+
+
+property numberOfReplicas : Integer;
+
+main() {
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var allocationContexts : Set(AllocationContext) := allocation.allocationContexts_Allocation;
+	var assemblyContexts : Set(AssemblyContext);
+	allocationContexts -> forEach(allocationContext){assemblyContexts += allocationContext.assemblyContext_AllocationContext;};
+	var system : System := allocation.system_Allocation;
+	var appliedStereotype : String;
+	
+	if(isProfileApplied(system.oclAsType(EObject), dynamicHorizontalScalingAssemblyContextProfile) and
+		hasAppliedStereotype(system, dynamicHorizontalScalingAssemblyContextSystemStereotype) and
+		hasAppliedStereotype(assemblyContexts,replicableAssemblyContextStereotype)){
+			appliedStereotype := replicableAssemblyContextStereotype;	
+	}
+	else{				
+		assert fatal(isProfileApplied(system.oclAsType(EObject), staticAssemblyContextLoadbalancingProfile))
+			with log ("The system has no " + staticAssemblyContextLoadbalancingProfile + " applied!");	
+		
+		assert fatal(hasAppliedStereotype(system,staticAssemblyContextLoadbalancingSystemStereotype))
+			with log("The System is not a" + staticAssemblyContextLoadbalancingSystemStereotype + "!");
+			
+		if(hasAppliedStereotype(assemblyContexts,staticLoadbalancedAssemblyContextStereotype)){
+				appliedStereotype := staticLoadbalancedAssemblyContextStereotype;
+		};
+	};
+
+	
+	//get the stereotyped AssemblyContext
+	var loadBalancedAssemblyContext : AssemblyContext := assemblyContexts -> selectOne(assemblyContext : AssemblyContext |
+					hasAppliedStereotype(assemblyContext,appliedStereotype));
+					
+	assert fatal(loadBalancedAssemblyContext != null)
+		with log ("There is no Stereotype Application!");	
+		
+	assert fatal(appliedStereotypesEqualsOne(assemblyContexts,appliedStereotype))
+		with log ("There is more than one Stereotype Application that defines a replicable Assembly!");	
+		
+	numberOfReplicas := getIntTaggedValue(loadBalancedAssemblyContext, numberOfReplicasTaggedValue, appliedStereotype);
+	
+	//apply Stereotype OriginalAssemblyContext from the Loadbalanced Profile. Needed when the system should be scaled in				
+	if (not isProfileApplied(system.oclAsType(EObject), loadbalancedProfile)) {
+		applyProfile(system.oclAsType(EObject), loadbalancedProfile);
+	};
+	applyStereotype(loadBalancedAssemblyContext, originalAssemblyContextStereotype);
+	
+	//remove Stereotype Application ReplicableAssemblyContext from the AssemblyContext
+	//removeStereotypeApplications(loadBalancedAssemblyContext,"ReplicableAssemblyContext");
+	
+	var loadBalancedAllocationContext : AllocationContext := allocationContexts ->selectOne(allocationContext : AllocationContext | allocationContext.assemblyContext_AllocationContext.id = loadBalancedAssemblyContext.id);
+	
+	var loadBalancedResourceContainer : ResourceContainer := loadBalancedAllocationContext.resourceContainer_AllocationContext;
+	
+	//create the LoadBalancer BasicComponent and AssemblyContext
+	var loadBalancerComponent : RepositoryComponent := new BasicComponent(loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext);
+	var loadBalancerAssemblyContext : AssemblyContext := new AssemblyContext(loadBalancerComponent);
+	//apply Stereotype LoadbalancerAssemblyContext from the Loadbalanced Profile. Needed when the system should be scaled in				
+	applyStereotype(loadBalancerAssemblyContext,loadbalancerAssemblyContextStereotype);	
+	//duplicate the stereotyped AssemblyContext
+	var duplicatedAssemblyContexts : OrderedSet(AssemblyContext) := createDuplicatedAssemblyContexts(loadBalancedAssemblyContext);
+	
+	//connect the LoadBalancer Assembly Context with the stereotyped and duplicated AssemblyContext in the System
+	connectLoadBalancerAndAssemblyContexts(loadBalancedAssemblyContext,loadBalancerAssemblyContext,duplicatedAssemblyContexts);
+	
+	//create the ResourceContainer for the LoadBalancer and the duplicated AssemblyContext
+	var loadBalancerResourceContainer : ResourceContainer := createResourceContainerAndConnectionToLinkingResources(loadBalancedResourceContainer,"LoadBalancer");
+	var duplicatedComponentResourceContainer : OrderedSet(ResourceContainer) := createDuplicatedResourceContainer(loadBalancedResourceContainer,loadBalancedAllocationContext.entityName,duplicatedAssemblyContexts);
+	
+	//create the AllocationContexts for the LoadBalancer and the duplicated AssemblyContexts
+	new AllocationContext(loadBalancerAssemblyContext,loadBalancerResourceContainer);
+	duplicatedAssemblyContexts -> map createDuplicatedAllocationContexts(duplicatedComponentResourceContainer);
+}
+
+/**
+ * Creates the ResourceContainer for all duplicated AssemblyContexts
+ */
+helper createDuplicatedResourceContainer(loadBalancedResourceContainer : ResourceContainer, loadBalancedAllocationContextEntityName : String, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)):OrderedSet(ResourceContainer){
+	var i : Integer := 0;
+	var duplicatedResourceContainer : OrderedSet(ResourceContainer);
+	while(i<duplicatedAssemblyContextSet -> size()){
+		duplicatedResourceContainer += createResourceContainerAndConnectionToLinkingResources(loadBalancedResourceContainer,loadBalancedAllocationContextEntityName);
+		i := i+1;
+	};
+	
+	return duplicatedResourceContainer;
+}
+
+/**
+ * Creates the AllocationContexts for all duplicated AssemblyContexts and ResourceContainer
+ */
+mapping OrderedSet(AssemblyContext) :: createDuplicatedAllocationContexts(resourceContainer : OrderedSet(ResourceContainer)):OrderedSet(AllocationContext){
+	var counter : Integer := 1;
+	self ->forEach(duplicatedAssemblyContext){
+		new AllocationContext(duplicatedAssemblyContext,resourceContainer -> at(counter));
+		counter := counter+1;
+	}
+}
+
+/**
+ * Creates a number, defined in the property numberOfReplicas, of duplicated AssemblyContexts  
+ * for the loadbalancedAssemblyContext
+ */
+helper createDuplicatedAssemblyContexts(loadbalancedAssemblyContext : AssemblyContext) : OrderedSet(AssemblyContext){
+	var counter : Integer := 1;
+	var duplicatedAssemblyContextSet : OrderedSet(AssemblyContext);
+	var duplicateAssemblyContext : AssemblyContext;
+	while(counter < numberOfReplicas){
+		duplicateAssemblyContext := new AssemblyContext(loadbalancedAssemblyContext.encapsulatedComponent__AssemblyContext);
+		//apply Stereotype LoadbalancerAssemblyContext from the Loadbalanced Profile. Needed when the system should be scaled in				
+		applyStereotype(duplicateAssemblyContext,duplicateAssemblyContextStereotype);
+		duplicatedAssemblyContextSet +=duplicateAssemblyContext;
+		counter := counter+1;
+	};
+	return duplicatedAssemblyContextSet;
+}
+
+/**
+ * Creates  connections between the AssemblyContext, previously connected with the stereotyped AssemblyContext, and the LoadBalancer. 
+ * Then it connects the LoadBalancer with the stereotyped and duplicate AssemblyContext.
+ * Afterward, it connects the new AssemblyContexts with ProvidedRoles of required AssemblyContexts or a SystemOperationRequiredRole.
+ */
+helper connectLoadBalancerAndAssemblyContexts(loadBalancedAssemblyContext : AssemblyContext, loadBalancerAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext):= duplicatedAssemblyContextSet;
+	duplicatedAssemblyContextsAndLoadBalancedAssemblyContext+= loadBalancedAssemblyContext;
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation;
+	var connectors : Set(Connector) := system.connectors__ComposedStructure;
+	
+	connectors->forEach(connector) {
+		if(connector.oclIsTypeOf(AssemblyConnector)){
+			var assemblyConnector : AssemblyConnector := connector.oclAsType(AssemblyConnector);
+			var requiringAssemblyContext : AssemblyContext := getRequiringAssemblyContext(assemblyConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(assemblyConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var oldAssemblyConnectorProvidedInterface := assemblyConnector.providedRole_AssemblyConnector.providedInterface__OperationProvidedRole;
+				
+				//get all ProvidedRoles of the LoadBalancer component and then get this one whose interface equals the interface of the ProvidedRole of the AssemblyConnector
+				var loadBalancerProvidedRoles : Set(OperationProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+				var commonProvidedRoleOfAssemblyConnectorAndLoadbalancer : OperationProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : OperationProvidedRole | providedRole.providedInterface__OperationProvidedRole.id = oldAssemblyConnectorProvidedInterface.id);
+				assert fatal(commonProvidedRoleOfAssemblyConnectorAndLoadbalancer != null)
+					with log ("Did not find common provided role for loadbalancer "+loadBalancerAssemblyContext.entityName+" and assembly connector "+assemblyConnector.entityName+"!");
+		
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(OperationRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(OperationRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(OperationRequiredRole) := loadBalancerAllRequiredRoles -> select(operationRequiredRole:OperationRequiredRole|operationRequiredRole.requiredInterface__OperationRequiredRole.id=assemblyConnector.providedRole_AssemblyConnector.providedInterface__OperationProvidedRole.id);
+				
+				//change the ProvidedRole and the ProvidingAssemblyContext of the AssemblyConnector to the LoadBalancer
+				assemblyConnector.providingAssemblyContext_AssemblyConnector := loadBalancerAssemblyContext;
+				assemblyConnector.providedRole_AssemblyConnector := commonProvidedRoleOfAssemblyConnectorAndLoadbalancer;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(oldAssemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+		else if(connector.oclIsTypeOf(AssemblyInfrastructureConnector)){
+			var assemblyInfrastructureConnector : AssemblyInfrastructureConnector := connector.oclAsType(AssemblyInfrastructureConnector);
+			var requiringAssemblyContext : AssemblyContext := getRequiringAssemblyContext(assemblyInfrastructureConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(assemblyInfrastructureConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var oldAssemblyConnectorProvidedInterface := assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.providedInterface__InfrastructureProvidedRole;
+				
+				//get all ProvidedRoles of the LoadBalancer component and then get this one whose interface equals the interface of the ProvidedRole of the AssemblyConnector
+				var loadBalancerProvidedRoles : Set(InfrastructureProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+				var commonProvidedRoleOfAssemblyConnectorAndLoadbalancer : InfrastructureProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : InfrastructureProvidedRole | providedRole.providedInterface__InfrastructureProvidedRole.id = oldAssemblyConnectorProvidedInterface.id);
+				assert fatal(commonProvidedRoleOfAssemblyConnectorAndLoadbalancer != null)
+					with log ("Did not find common provided role for loadbalancer "+loadBalancerAssemblyContext.entityName+" and assembly connector "+assemblyInfrastructureConnector.entityName+"!");
+		
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(InfrastructureRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAllRequiredRoles -> select(infrastructureRequiredRole:InfrastructureRequiredRole|
+					infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id=assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.providedInterface__InfrastructureProvidedRole.id);
+				
+				//change the ProvidedRole and the ProvidingAssemblyContext of the AssemblyConnector to the LoadBalancer
+				assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector := loadBalancerAssemblyContext;
+				assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector := commonProvidedRoleOfAssemblyConnectorAndLoadbalancer;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(oldAssemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+		else if(connector.oclIsTypeOf(ProvidedInfrastructureDelegationConnector)){
+			var delegationConnector : ProvidedInfrastructureDelegationConnector := connector.oclAsType(ProvidedInfrastructureDelegationConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(delegationConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var delegationConnectorProvidedInterface := delegationConnector.innerProvidedRole__ProvidedInfrastructureDelegationConnector.providedInterface__InfrastructureProvidedRole;
+				var loadBalancerProvidedRoles : Set(InfrastructureProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+				var commonProvidedRoleOfDelegationConnectorAndLoadbalancer : InfrastructureProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : InfrastructureProvidedRole| providedRole.providedInterface__InfrastructureProvidedRole.id = delegationConnectorProvidedInterface.id );
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(InfrastructureRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAllRequiredRoles -> select(infrastructureRequiredRole:InfrastructureRequiredRole|infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id=delegationConnectorProvidedInterface.id);
+				//change the InnerProvidedRole and the AssemblyContext of the DelegationConnector to the LoadBalancer
+				delegationConnector.innerProvidedRole__ProvidedInfrastructureDelegationConnector := commonProvidedRoleOfDelegationConnectorAndLoadbalancer;
+				delegationConnector.assemblyContext__ProvidedInfrastructureDelegationConnector := loadBalancerAssemblyContext;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(delegationConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+			
+		}
+		else if (connector.oclIsTypeOf(ProvidedDelegationConnector)) {
+			var delegationConnector : ProvidedDelegationConnector := connector.oclAsType(ProvidedDelegationConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(delegationConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var delegationConnectorProvidedInterface := delegationConnector.innerProvidedRole_ProvidedDelegationConnector.providedInterface__OperationProvidedRole;
+				var loadBalancerProvidedRoles : Set(OperationProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+				var commonProvidedRoleOfDelegationConnectorAndLoadbalancer : OperationProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : OperationProvidedRole| providedRole.providedInterface__OperationProvidedRole.id = delegationConnectorProvidedInterface.id );
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(OperationRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(OperationRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(OperationRequiredRole) := loadBalancerAllRequiredRoles -> select(operationRequiredRole:OperationRequiredRole|operationRequiredRole.requiredInterface__OperationRequiredRole.id=delegationConnectorProvidedInterface.id);
+				//change the InnerProvidedRole and the AssemblyContext of the DelegationConnector to the LoadBalancer
+				delegationConnector.innerProvidedRole_ProvidedDelegationConnector := commonProvidedRoleOfDelegationConnectorAndLoadbalancer;
+				delegationConnector.assemblyContext_ProvidedDelegationConnector := loadBalancerAssemblyContext;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(delegationConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+	};
+	//Connect the duplicated AssemblyContext with required AssemblyContexts 
+	if (loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity != null){
+					addRequiredRolesAssemblyConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+					addRequiredRolesSystemDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+					addRequiredRolesAssemblyInfrastructureConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+				    addRequiredRolesInfrastructureDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+	};
+}
+
+helper createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(operationInterface:OperationInterface,loadBalancerAssemblyContext : AssemblyContext,loadBalancerNeededRequiredRoles : Set(OperationRequiredRole),duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext)){
+	var counter : Integer := 1;
+	loadBalancerNeededRequiredRoles -> forEach(loadBalancerNeededRequiredRole){
+		var system : System := loadBalancerAssemblyContext.parentStructure__AssemblyContext![System];
+		var targetAssemblyContext : AssemblyContext := duplicatedAssemblyContextsAndLoadBalancedAssemblyContext->at(counter);
+		var targetAssemblyContextProvidedRoles : Set(OperationProvidedRole) := targetAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+		var targetAssemblyContextProvidedRole : OperationProvidedRole := targetAssemblyContextProvidedRoles -> selectOne(op:OperationProvidedRole|op.providedInterface__OperationProvidedRole.id = operationInterface.id);
+		if(system.connectors__ComposedStructure[AssemblyConnector]->select(assemblyConnector | 
+																		assemblyConnector.providingAssemblyContext_AssemblyConnector.id = targetAssemblyContext.id 
+																		and assemblyConnector.requiringAssemblyContext_AssemblyConnector.id = loadBalancerAssemblyContext.id 
+																		and assemblyConnector.providedRole_AssemblyConnector.id = targetAssemblyContextProvidedRole.id
+																		and assemblyConnector.requiredRole_AssemblyConnector.id = loadBalancerNeededRequiredRole.id)->isEmpty()){
+			new AssemblyConnector(loadBalancerAssemblyContext,loadBalancerNeededRequiredRole,targetAssemblyContextProvidedRole,targetAssemblyContext);		
+		};				
+		targetAssemblyContextProvidedRoles := targetAssemblyContextProvidedRoles->excluding(targetAssemblyContextProvidedRole);
+		counter:=counter+1;
+	};
+}
+
+helper createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(infrastructureInterface:InfrastructureInterface,loadBalancerAssemblyContext : AssemblyContext,loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole),duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext)){
+	var counter : Integer := 1;
+	loadBalancerNeededRequiredRoles -> forEach(loadBalancerNeededRequiredRole){
+		var system : System := loadBalancerAssemblyContext.parentStructure__AssemblyContext![System];
+		var targetAssemblyContext : AssemblyContext := duplicatedAssemblyContextsAndLoadBalancedAssemblyContext->at(counter);
+		var targetAssemblyContextProvidedRoles : Set(InfrastructureProvidedRole) := targetAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+		var targetAssemblyContextProvidedRole : InfrastructureProvidedRole := targetAssemblyContextProvidedRoles -> selectOne(op:InfrastructureProvidedRole|op.providedInterface__InfrastructureProvidedRole.id = infrastructureInterface.id);
+		if(system.connectors__ComposedStructure[AssemblyInfrastructureConnector]->select(assemblyInfrastructureConnector | 
+																						assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector.id = targetAssemblyContext.id 
+																						and assemblyInfrastructureConnector.requiringAssemblyContext__AssemblyInfrastructureConnector.id = loadBalancerAssemblyContext.id
+																						and assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.id = targetAssemblyContextProvidedRole.id
+																						and assemblyInfrastructureConnector.requiredRole__AssemblyInfrastructureConnector.id = loadBalancerNeededRequiredRole.id)->isEmpty()){
+			new AssemblyInfrastructureConnector(loadBalancerAssemblyContext,loadBalancerNeededRequiredRole,targetAssemblyContextProvidedRole,targetAssemblyContext);	
+		};					
+		targetAssemblyContextProvidedRoles := targetAssemblyContextProvidedRoles->excluding(targetAssemblyContextProvidedRole);
+		counter:=counter+1;
+	}
+}
+
+/**
+ * Creates an AssemblyConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * an OperationRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesAssemblyConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	var assemblyConnectors : Collection(AssemblyConnector) := system.connectors__ComposedStructure ->selectByType(AssemblyConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextConnectors : Collection(AssemblyConnector) := assemblyConnectors -> select(assemblyConnector : AssemblyConnector | loadBalancedRequiredRoles -> includes(assemblyConnector.requiredRole_AssemblyConnector));
+	requiredRoleLoadBalancedAssemblyContextConnectors -> forEach(assemblyConnector){
+		duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+			new AssemblyConnector(duplicatedAssemblyContext,assemblyConnector.requiredRole_AssemblyConnector,assemblyConnector.providedRole_AssemblyConnector,assemblyConnector.providingAssemblyContext_AssemblyConnector);
+			
+		}
+	};
+};
+
+/**
+ * Creates an AssemblyInfrastructureConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * an InfrastructureRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesAssemblyInfrastructureConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	var assemblyInfrastructureConnectors : Collection(AssemblyInfrastructureConnector) := system.connectors__ComposedStructure ->selectByType(AssemblyInfrastructureConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextConnectors : Collection(AssemblyInfrastructureConnector) := assemblyInfrastructureConnectors -> select(assemblyInfrastructureConnector : AssemblyInfrastructureConnector | loadBalancedRequiredRoles -> includes(assemblyInfrastructureConnector.requiredRole__AssemblyInfrastructureConnector));
+	requiredRoleLoadBalancedAssemblyContextConnectors -> forEach(assemblyConnector){
+		duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+			new AssemblyInfrastructureConnector(duplicatedAssemblyContext,assemblyConnector.requiredRole__AssemblyInfrastructureConnector,assemblyConnector.providedRole__AssemblyInfrastructureConnector,assemblyConnector.providingAssemblyContext__AssemblyInfrastructureConnector);
+			
+		}
+	};
+};
+
+/**
+ * Creates a RequiredSystemDelegationConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * the SystemOperationRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesSystemDelegationConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	var delegationConnectors : Collection(RequiredDelegationConnector) := system.connectors__ComposedStructure -> selectByType(RequiredDelegationConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextDelegationConnectors : Collection(RequiredDelegationConnector) := delegationConnectors -> select(delegationConnector : RequiredDelegationConnector | loadBalancedRequiredRoles -> includes(delegationConnector.innerRequiredRole_RequiredDelegationConnector));
+	requiredRoleLoadBalancedAssemblyContextDelegationConnectors -> forEach(delegationConnector){
+	duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+		new RequiredDelegationConnector(duplicatedAssemblyContext,delegationConnector.innerRequiredRole_RequiredDelegationConnector,delegationConnector.outerRequiredRole_RequiredDelegationConnector);
+		}
+	};
+};
+
+/**
+ * Creates a RequiredInfrastructureDelegationConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * the InfrastructureRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesInfrastructureDelegationConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	var delegationConnectors : Collection(RequiredInfrastructureDelegationConnector) := system.connectors__ComposedStructure -> selectByType(RequiredInfrastructureDelegationConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextDelegationConnectors : Collection(RequiredInfrastructureDelegationConnector) := delegationConnectors -> select(delegationConnector : RequiredInfrastructureDelegationConnector | loadBalancedRequiredRoles -> includes(delegationConnector.innerRequiredRole__RequiredInfrastructureDelegationConnector));
+	requiredRoleLoadBalancedAssemblyContextDelegationConnectors -> forEach(delegationConnector){
+	duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+		new RequiredInfrastructureDelegationConnector(duplicatedAssemblyContext,delegationConnector.innerRequiredRole__RequiredInfrastructureDelegationConnector,delegationConnector.outerRequiredRole__RequiredInfrastructureDelegationConnector);
+		}
+	};
+};
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(providedDelegationConnector : ProvidedDelegationConnector) : AssemblyContext {
+	return providedDelegationConnector.assemblyContext_ProvidedDelegationConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(providedDelegationConnector : ProvidedInfrastructureDelegationConnector) : AssemblyContext {
+	return providedDelegationConnector.assemblyContext__ProvidedInfrastructureDelegationConnector;
+}
+
+/**
+ * Returns the requiring component of a given connector.
+ */
+query getRequiringAssemblyContext(assemblyConnector : AssemblyConnector) : AssemblyContext {
+	return assemblyConnector.requiringAssemblyContext_AssemblyConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(assemblyConnector : AssemblyConnector) : AssemblyContext {
+	return assemblyConnector.providingAssemblyContext_AssemblyConnector;
+}
+
+/**
+ * Returns the requiring component of a given connector.
+ */
+query getRequiringAssemblyContext(assemblyInfrastructureConnector : AssemblyInfrastructureConnector) : AssemblyContext {
+	return assemblyInfrastructureConnector.requiringAssemblyContext__AssemblyInfrastructureConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(assemblyInfrastructureConnector : AssemblyInfrastructureConnector) : AssemblyContext {
+	return assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector;
+}
+
+/** Returns a new ResourceContainer that equals the ResourceContainer specifications'' of the input parameter. It is also connected with the same LinkingResource
+*/
+helper createResourceContainerAndConnectionToLinkingResources(originalResourceContainer:ResourceContainer, name:String):ResourceContainer{
+	var resourceContainer : ResourceContainer := new ResourceContainer(originalResourceContainer,name);
+	var resourceContainerLinkingResources :=
+			originalResourceContainer.resourceEnvironment_ResourceContainer.linkingResources__ResourceEnvironment 
+			-> select( l :LinkingResource |
+				l.connectedResourceContainers_LinkingResource
+				->includes(originalResourceContainer)
+			);
+	//create a LinkingResource in the ResourcesEnvironment when none exists
+	//FIXME: parameters of latency and throughput for the CommunicationLinkResourceSpecification should be changed, or they should be defined by the user
+	if (resourceContainerLinkingResources->isEmpty()){
+		resourceContainerLinkingResources += new LinkingResource(originalResourceContainer,"0","10000");
+	};
+	
+	resourceContainerLinkingResources
+		->forEach(linkingResource){
+			linkingResource.connectedResourceContainers_LinkingResource += resourceContainer;
+		};
+	
+	return resourceContainer;
+};
+
+constructor RequiredDelegationConnector :: RequiredDelegationConnector(assemblyContext : AssemblyContext, innerRequiredRole : OperationRequiredRole, outerRequiredRole : OperationRequiredRole){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	entityName := "RequiredDelegation " + innerRequiredRole.entityName + "_" + outerRequiredRole.entityName;
+	assemblyContext_RequiredDelegationConnector := assemblyContext;
+	innerRequiredRole_RequiredDelegationConnector := innerRequiredRole;
+	outerRequiredRole_RequiredDelegationConnector := outerRequiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor RequiredInfrastructureDelegationConnector :: RequiredInfrastructureDelegationConnector(assemblyContext : AssemblyContext, innerRequiredRole : InfrastructureRequiredRole, outerRequiredRole : InfrastructureRequiredRole){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	entityName := "RequiredDelegation " + innerRequiredRole.entityName + "_" + outerRequiredRole.entityName;
+	assemblyContext__RequiredInfrastructureDelegationConnector := assemblyContext;
+	innerRequiredRole__RequiredInfrastructureDelegationConnector := innerRequiredRole;
+	outerRequiredRole__RequiredInfrastructureDelegationConnector := outerRequiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor AssemblyConnector :: AssemblyConnector(requiringAssemblyContext : AssemblyContext,requiredRole:OperationRequiredRole, providedRole: OperationProvidedRole, providingAssemblyContext : AssemblyContext){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	entityName := requiringAssemblyContext.entityName + "_" + providingAssemblyContext.entityName;
+	providingAssemblyContext_AssemblyConnector := providingAssemblyContext;
+	requiringAssemblyContext_AssemblyConnector := requiringAssemblyContext;
+	providedRole_AssemblyConnector := providedRole;
+	requiredRole_AssemblyConnector := requiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor AssemblyInfrastructureConnector :: AssemblyInfrastructureConnector(requiringAssemblyContext : AssemblyContext,requiredRole:InfrastructureRequiredRole, providedRole: InfrastructureProvidedRole, providingAssemblyContext : AssemblyContext){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	entityName := requiringAssemblyContext.entityName + "_" + providingAssemblyContext.entityName;
+	providingAssemblyContext__AssemblyInfrastructureConnector := providingAssemblyContext;
+	requiringAssemblyContext__AssemblyInfrastructureConnector := requiringAssemblyContext;
+	providedRole__AssemblyInfrastructureConnector := providedRole;
+	requiredRole__AssemblyInfrastructureConnector := requiredRole;
+	parentStructure__Connector := system;
+}
+
+constructor LinkingResource :: LinkingResource (resourceContainer : ResourceContainer, latency : String, throughput : String){
+	connectedResourceContainers_LinkingResource := resourceContainer;
+	resourceEnvironment_LinkingResource := resourceContainer.resourceEnvironment_ResourceContainer;
+	communicationLinkResourceSpecifications_LinkingResource := new CommunicationLinkResourceSpecification(resourceContainer,latency,throughput);
+}
+
+constructor CommunicationLinkResourceSpecification :: CommunicationLinkResourceSpecification(resourceContainer : ResourceContainer, latency : String, throughput : String){
+	latency_CommunicationLinkResourceSpecification := new PCMRandomVariable(latency);
+	throughput_CommunicationLinkResourceSpecification := new PCMRandomVariable(throughput);
+	communicationLinkResourceType_CommunicationLinkResourceSpecification := resourceContainer.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification.resourceRepository_ResourceType.availableResourceTypes_ResourceRepository->selectByType(CommunicationLinkResourceType)->selectOne(resourceType : ResourceType |resourceType.id = "_o3sScH2AEdyH8uerKnHYug");
+}
+
+constructor AllocationContext :: AllocationContext (ac : AssemblyContext, rc: ResourceContainer){
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	entityName := "Allocation_" + ac.entityName;
+	assemblyContext_AllocationContext := ac;
+	resourceContainer_AllocationContext := rc;
+	allocation_AllocationContext := allocation;
+}
+
+constructor ProcessingResourceSpecification:: ProcessingResourceSpecification(p:ProcessingResourceSpecification, rc : ResourceContainer){
+	MTTF := p.MTTF;
+	MTTR := p.MTTR;
+	schedulingPolicy := p.schedulingPolicy;
+	requiredByContainer := p.requiredByContainer;
+	processingRate_ProcessingResourceSpecification := new PCMRandomVariable(p.processingRate_ProcessingResourceSpecification);
+	numberOfReplicas := p.numberOfReplicas;
+	activeResourceType_ActiveResourceSpecification := p.activeResourceType_ActiveResourceSpecification;
+	resourceContainer_ProcessingResourceSpecification := rc;
+}
+
+/**Creates a PCMRandomVariable from an existing PCMRandomVariable
+*/
+constructor PCMRandomVariable :: PCMRandomVariable(pcmRandomVariable:PCMRandomVariable){
+	specification := pcmRandomVariable.specification;
+}
+
+/**Creates a PCMRandomVariable with a specified input parameter
+*/
+constructor PCMRandomVariable :: PCMRandomVariable(spec:String){
+	specification := spec;
+}
+
+constructor ResourceContainer :: ResourceContainer(originalResourceContainer : ResourceContainer, rcName : String){
+	entityName := originalResourceContainer.entityName + rcName;
+	resourceEnvironment_ResourceContainer := originalResourceContainer.resourceEnvironment_ResourceContainer;
+	
+	if(originalResourceContainer.nestedResourceContainers__ResourceContainer->size()>0)	{
+		nestedResourceContainers__ResourceContainer := originalResourceContainer.duplicateNestedResourceContainer();
+	};
+	
+	activeResourceSpecifications_ResourceContainer += originalResourceContainer.activeResourceSpecifications_ResourceContainer -> forEach(activeResource){
+		new ProcessingResourceSpecification(activeResource, result);
+	};
+} 
+
+helper ResourceContainer::duplicateNestedResourceContainer():Set(ResourceContainer){
+	var nestedResourceContainer : Set(ResourceContainer);
+	self.nestedResourceContainers__ResourceContainer->forEach(rc){
+		nestedResourceContainer += new ResourceContainer(rc, rc.entityName);	
+	};
+
+	return nestedResourceContainer;
+}
+
+constructor AssemblyContext :: AssemblyContext(bc : RepositoryComponent) {
+	entityName := "Assembly_"+bc.entityName;
+	encapsulatedComponent__AssemblyContext := bc;
+	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	var system : System := allocation.system_Allocation![System];
+	parentStructure__AssemblyContext := system;
+}
+
+constructor BasicComponent :: BasicComponent (loadBalancedComponent : RepositoryComponent)
+{
+	var repository := loadBalancedComponent.repository__RepositoryComponent;
+	var providedRoles : Set(ProvidedRole) := loadBalancedComponent.providedRoles_InterfaceProvidingEntity;
+	entityName := "LoadBalancer_"+ loadBalancedComponent.entityName;
+	repository__RepositoryComponent := repository;
+	providedRoles -> forEach(providedRole){
+		if(providedRole.oclIsTypeOf(OperationProvidedRole)){
+			var counter : Integer := 1;
+			providedRoles_InterfaceProvidingEntity += new OperationProvidedRole(providedRole.oclAsType(OperationProvidedRole));
+			while(counter<= (numberOfReplicas)){
+				requiredRoles_InterfaceRequiringEntity += new OperationRequiredRole(providedRole.oclAsType(OperationProvidedRole),counter);
+				counter := counter+1;
+			};
+		}else if(providedRole.oclIsTypeOf(InfrastructureProvidedRole)){
+			var counter : Integer := 1;
+			providedRoles_InterfaceProvidingEntity += new InfrastructureProvidedRole(providedRole.oclAsType(InfrastructureProvidedRole));
+			while(counter<= (numberOfReplicas)){
+				requiredRoles_InterfaceRequiringEntity += new InfrastructureRequiredRole(providedRole.oclAsType(InfrastructureProvidedRole),counter);
+				counter := counter+1;
+			};
+		};
+	};
+	
+	componentParameterUsage_ImplementationComponentType := loadBalancedComponent[ImplementationComponentType].componentParameterUsage_ImplementationComponentType;
+	
+	providedRoles_InterfaceProvidingEntity -> forEach(providedRole){
+	if(providedRole.oclIsTypeOf(OperationProvidedRole)){
+		var operationProvidedRole := providedRole.oclAsType(OperationProvidedRole);
+		var operationInterface := operationProvidedRole.providedInterface__OperationProvidedRole;
+		var operationRequiredRoles : Set(OperationRequiredRole) := requiredRoles_InterfaceRequiringEntity ->selectByType(OperationRequiredRole);
+		var requiredRolesWithSameInterfaceAsProvidedRole : Set(OperationRequiredRole) := operationRequiredRoles -> select(operationRequiredRole : OperationRequiredRole | operationRequiredRole.requiredInterface__OperationRequiredRole.id = operationInterface.id);
+		operationInterface.signatures__OperationInterface->forEach(operationSignature){
+	  		serviceEffectSpecifications__BasicComponent += new ResourceDemandingSEFF(operationSignature, requiredRolesWithSameInterfaceAsProvidedRole);
+		};
+		}else if(providedRole.oclIsTypeOf(InfrastructureProvidedRole)){
+			var infrastructureProvidedRole := providedRole.oclAsType(InfrastructureProvidedRole);
+			var infrastructureInterface := infrastructureProvidedRole.providedInterface__InfrastructureProvidedRole;
+			var infrastructureRequiredRoles : Set(InfrastructureRequiredRole) := requiredRoles_InterfaceRequiringEntity ->selectByType(InfrastructureRequiredRole);
+			var requiredRolesWithSameInterfaceAsProvidedRole : Set(InfrastructureRequiredRole) := infrastructureRequiredRoles -> select(infrastructureRequiredRole : InfrastructureRequiredRole | infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id = infrastructureInterface.id);
+			infrastructureInterface.infrastructureSignatures__InfrastructureInterface->forEach(infrastructureSignature){
+  				serviceEffectSpecifications__BasicComponent += new ResourceDemandingSEFF(infrastructureSignature, requiredRoles_InterfaceRequiringEntity[InfrastructureRequiredRole]);
+	};
+		};
+	}
+}
+
+constructor ResourceDemandingSEFF :: ResourceDemandingSEFF (operationSignature : OperationSignature, requiredRoles : Set(OperationRequiredRole)){
+	describedService__SEFF := operationSignature;
+	var startAction : StartAction := object StartAction{};
+	var branchAction : BranchAction := object BranchAction{
+		entityName := "LoadBalancer Branch";
+		predecessor_AbstractAction := startAction;
+		
+		requiredRoles->forEach(requiredRole){
+		    var probability : Real := 1.0 / requiredRoles->size();
+			branches_Branch += object ProbabilisticBranchTransition{
+			    entityName := "Branch for "+requiredRole.entityName;
+			    branchProbability := probability;
+			    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+			    	var innerStartAction : StartAction := object StartAction{};
+			    	var delegatingExternalCallAction : DelegatingExternalCallAction := object DelegatingExternalCallAction{
+			    		predecessor_AbstractAction := innerStartAction;
+			    		entityName := "Call "+operationSignature.entityName;
+			    		role_ExternalService := requiredRole;
+			    		calledService_ExternalService := operationSignature;
+			    	};
+			    	var innerStopAction : StopAction := object StopAction{
+						predecessor_AbstractAction := delegatingExternalCallAction;
+					};
+					
+					steps_Behaviour += innerStartAction;
+					steps_Behaviour += delegatingExternalCallAction;
+					steps_Behaviour += innerStopAction;
+			    };
+			};
+		};
+	};
+	var stopAction : StopAction := object StopAction{
+		predecessor_AbstractAction := branchAction;
+	};
+	steps_Behaviour += startAction;
+	steps_Behaviour += branchAction;
+	steps_Behaviour += stopAction;
+}
+
+constructor ResourceDemandingSEFF::ResourceDemandingSEFF (infrastructureSignature : InfrastructureSignature, requiredRoles : Set(InfrastructureRequiredRole)){
+	describedService__SEFF := infrastructureSignature;
+	var startAction : StartAction := object StartAction{};
+	var branchAction : BranchAction := object BranchAction{
+		entityName := "LoadBalancer Branch";
+		predecessor_AbstractAction := startAction;
+		
+		requiredRoles->forEach(requiredRole){
+		    var probability : Real := 1.0 / requiredRoles->size();
+			branches_Branch += object ProbabilisticBranchTransition{
+			    entityName := "Branch for "+requiredRole.entityName;
+			    branchProbability := probability;
+			    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+			    	var innerStartAction : StartAction := object StartAction{};
+			    	var internalCallAction : InternalAction:= object InternalAction{
+			    		entityName := "Call "+infrastructureSignature.entityName;
+			    		predecessor_AbstractAction := innerStartAction;
+			    		infrastructureCall__Action := object InfrastructureCall{
+			    			entityName := "InfrastructureCall " + requiredRole.entityName;
+			    			signature__InfrastructureCall := infrastructureSignature;
+			    			requiredRole__InfrastructureCall := requiredRole;
+			    			numberOfCalls__InfrastructureCall := new PCMRandomVariable("1");
+			    		};
+			    	};
+			    	var innerStopAction : StopAction := object StopAction{
+						predecessor_AbstractAction := internalCallAction;
+					};
+					
+					steps_Behaviour += innerStartAction;
+					steps_Behaviour += internalCallAction;
+					steps_Behaviour += innerStopAction;
+			    };
+			};
+		};
+	};
+	var stopAction : StopAction := object StopAction{
+		predecessor_AbstractAction := branchAction;
+	};
+	steps_Behaviour += startAction;
+	steps_Behaviour += branchAction;
+	steps_Behaviour += stopAction;
+}	
+
+constructor OperationProvidedRole :: OperationProvidedRole(pr:OperationProvidedRole){
+	entityName := "Provided_" + pr.providedInterface__OperationProvidedRole.entityName + "_LoadBalancer";
+	providedInterface__OperationProvidedRole := pr.providedInterface__OperationProvidedRole;
+}
+
+constructor OperationRequiredRole :: OperationRequiredRole(rr:OperationProvidedRole, i:Integer){
+	entityName := "Required_" + rr.providedInterface__OperationProvidedRole.entityName +"_LoadBalancer_"+i.toString();
+	requiredInterface__OperationRequiredRole := rr.providedInterface__OperationProvidedRole;
+}
+
+constructor InfrastructureProvidedRole::InfrastructureProvidedRole(providedRole : InfrastructureProvidedRole){
+	entityName := "Provided_" + providedRole.providedInterface__InfrastructureProvidedRole.entityName + "_LoadBalancer";
+	providedInterface__InfrastructureProvidedRole := providedRole.providedInterface__InfrastructureProvidedRole;
+}
+
+constructor InfrastructureRequiredRole::InfrastructureRequiredRole(providedRole : InfrastructureProvidedRole, counter : Integer){
+	entityName := "Required_" + providedRole.providedInterface__InfrastructureProvidedRole.entityName +"_LoadBalancer_"+counter.toString();
+	requiredInterface__InfrastructureRequiredRole := providedRole.providedInterface__InfrastructureProvidedRole;
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Wiring.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Wiring.qvto
@@ -1,0 +1,292 @@
+import org.palladiosimulator.architecturaltemplates.catalog.black.ProfilesLibrary;
+import Constructors;
+
+modeltype ECORE uses 'http://www.eclipse.org/emf/2002/Ecore';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCMComposition uses pcm::core::composition('http://palladiosimulator.org/PalladioComponentModel/5.2');
+modeltype PCMSEFF uses pcm::seff('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCM_COMPLETION uses 'http://palladiosimulator.org/AnalyzerFramework/Completions/1.0';
+modeltype PCMSEFF_PERFORMANCE uses pcm::seff::seff_performance('http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2');
+modeltype PCM_RESOURCETYPE uses pcm::resourcetype('http://palladiosimulator.org/PalladioComponentModel/5.2');
+
+library Wiring();
+
+
+helper connectExistingLoadBalancerAndNewAssemblyContexts(loadBalancedAssemblyContext : AssemblyContext, loadBalancerAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext), inout system:System){
+	var duplicatedAssemblyContexts : OrderedSet(AssemblyContext):= duplicatedAssemblyContextSet;
+	var connectors : Set(Connector) := system.connectors__ComposedStructure;
+	var loadBalancerAllRequiredRoles : Set(OperationRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(OperationRequiredRole);
+	var loadBalancerNeededRequiredRoles : Set(OperationRequiredRole) := Set{};
+	var loadBalancerFilledRequiredRoles : Set(OperationRequiredRole) := Set{};
+	var assemblyConnectorProvidedInterface:OperationInterface := null;
+	
+	connectors->forEach(connector){
+		if(connector.oclIsTypeOf(AssemblyConnector)){
+			var assemblyConnector : AssemblyConnector := connector.oclAsType(AssemblyConnector);
+			if(loadBalancerAllRequiredRoles->includes(assemblyConnector.requiredRole_AssemblyConnector)){
+				assemblyConnectorProvidedInterface := assemblyConnector.providedRole_AssemblyConnector.providedInterface__OperationProvidedRole;
+				loadBalancerFilledRequiredRoles += assemblyConnector.requiredRole_AssemblyConnector;
+			}
+		}
+	};
+	
+	loadBalancerNeededRequiredRoles := loadBalancerAllRequiredRoles - loadBalancerFilledRequiredRoles;
+	createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(assemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContexts);
+	
+}
+
+
+/**
+ * Creates  connections between the AssemblyContext, previously connected with the stereotyped AssemblyContext, and the LoadBalancer. 
+ * Then it connects the LoadBalancer with the stereotyped and duplicate AssemblyContext.
+ * Afterward, it connects the new AssemblyContexts with ProvidedRoles of required AssemblyContexts or a SystemOperationRequiredRole.
+ */
+helper connectLoadBalancerAndAssemblyContexts(loadBalancedAssemblyContext : AssemblyContext, loadBalancerAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext), inout system:System){
+	var duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext):= duplicatedAssemblyContextSet;
+	duplicatedAssemblyContextsAndLoadBalancedAssemblyContext+= loadBalancedAssemblyContext;
+//	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];
+	//var system : System := resolveone(System);
+	var connectors : Set(Connector) := system.connectors__ComposedStructure;
+	
+	connectors->forEach(connector) {
+		if(connector.oclIsTypeOf(AssemblyConnector)){
+			var assemblyConnector : AssemblyConnector := connector.oclAsType(AssemblyConnector);
+			var requiringAssemblyContext : AssemblyContext := getRequiringAssemblyContext(assemblyConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(assemblyConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var oldAssemblyConnectorProvidedInterface := assemblyConnector.providedRole_AssemblyConnector.providedInterface__OperationProvidedRole;
+				
+				//get all ProvidedRoles of the LoadBalancer component and then get this one whose interface equals the interface of the ProvidedRole of the AssemblyConnector
+				var loadBalancerProvidedRoles : Set(OperationProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+				var commonProvidedRoleOfAssemblyConnectorAndLoadbalancer : OperationProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : OperationProvidedRole | providedRole.providedInterface__OperationProvidedRole.id = oldAssemblyConnectorProvidedInterface.id);
+				assert fatal(commonProvidedRoleOfAssemblyConnectorAndLoadbalancer != null)
+					with log ("Did not find common provided role for loadbalancer "+loadBalancerAssemblyContext.entityName+" and assembly connector "+assemblyConnector.entityName+"!");
+		
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(OperationRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(OperationRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(OperationRequiredRole) := loadBalancerAllRequiredRoles -> select(operationRequiredRole:OperationRequiredRole|operationRequiredRole.requiredInterface__OperationRequiredRole.id=assemblyConnector.providedRole_AssemblyConnector.providedInterface__OperationProvidedRole.id);
+				
+				//change the ProvidedRole and the ProvidingAssemblyContext of the AssemblyConnector to the LoadBalancer
+				assemblyConnector.providingAssemblyContext_AssemblyConnector := loadBalancerAssemblyContext;
+				assemblyConnector.providedRole_AssemblyConnector := commonProvidedRoleOfAssemblyConnectorAndLoadbalancer;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(oldAssemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+		else if(connector.oclIsTypeOf(AssemblyInfrastructureConnector)){
+			var assemblyInfrastructureConnector : AssemblyInfrastructureConnector := connector.oclAsType(AssemblyInfrastructureConnector);
+			var requiringAssemblyContext : AssemblyContext := getRequiringAssemblyContext(assemblyInfrastructureConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(assemblyInfrastructureConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var oldAssemblyConnectorProvidedInterface := assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.providedInterface__InfrastructureProvidedRole;
+				
+				//get all ProvidedRoles of the LoadBalancer component and then get this one whose interface equals the interface of the ProvidedRole of the AssemblyConnector
+				var loadBalancerProvidedRoles : Set(InfrastructureProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+				var commonProvidedRoleOfAssemblyConnectorAndLoadbalancer : InfrastructureProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : InfrastructureProvidedRole | providedRole.providedInterface__InfrastructureProvidedRole.id = oldAssemblyConnectorProvidedInterface.id);
+				assert fatal(commonProvidedRoleOfAssemblyConnectorAndLoadbalancer != null)
+					with log ("Did not find common provided role for loadbalancer "+loadBalancerAssemblyContext.entityName+" and assembly connector "+assemblyInfrastructureConnector.entityName+"!");
+		
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(InfrastructureRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAllRequiredRoles -> select(infrastructureRequiredRole:InfrastructureRequiredRole|
+					infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id=assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.providedInterface__InfrastructureProvidedRole.id);
+				
+				//change the ProvidedRole and the ProvidingAssemblyContext of the AssemblyConnector to the LoadBalancer
+				assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector := loadBalancerAssemblyContext;
+				assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector := commonProvidedRoleOfAssemblyConnectorAndLoadbalancer;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(oldAssemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+		else if(connector.oclIsTypeOf(ProvidedInfrastructureDelegationConnector)){
+			var delegationConnector : ProvidedInfrastructureDelegationConnector := connector.oclAsType(ProvidedInfrastructureDelegationConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(delegationConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var delegationConnectorProvidedInterface := delegationConnector.innerProvidedRole__ProvidedInfrastructureDelegationConnector.providedInterface__InfrastructureProvidedRole;
+				var loadBalancerProvidedRoles : Set(InfrastructureProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+				var commonProvidedRoleOfDelegationConnectorAndLoadbalancer : InfrastructureProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : InfrastructureProvidedRole| providedRole.providedInterface__InfrastructureProvidedRole.id = delegationConnectorProvidedInterface.id );
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(InfrastructureRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole) := loadBalancerAllRequiredRoles -> select(infrastructureRequiredRole:InfrastructureRequiredRole|infrastructureRequiredRole.requiredInterface__InfrastructureRequiredRole.id=delegationConnectorProvidedInterface.id);
+				//change the InnerProvidedRole and the AssemblyContext of the DelegationConnector to the LoadBalancer
+				delegationConnector.innerProvidedRole__ProvidedInfrastructureDelegationConnector := commonProvidedRoleOfDelegationConnectorAndLoadbalancer;
+				delegationConnector.assemblyContext__ProvidedInfrastructureDelegationConnector := loadBalancerAssemblyContext;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(delegationConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+			
+		}
+		else if (connector.oclIsTypeOf(ProvidedDelegationConnector)) {
+			log('oh its a delegation connectooor');
+			var delegationConnector : ProvidedDelegationConnector := connector.oclAsType(ProvidedDelegationConnector);
+			var providingAssemblyContext : AssemblyContext := getProvidingAssemblyContext(delegationConnector);
+			if(providingAssemblyContext = loadBalancedAssemblyContext){
+				var delegationConnectorProvidedInterface := delegationConnector.innerProvidedRole_ProvidedDelegationConnector.providedInterface__OperationProvidedRole;
+				var loadBalancerProvidedRoles : Set(OperationProvidedRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+				var commonProvidedRoleOfDelegationConnectorAndLoadbalancer : OperationProvidedRole := loadBalancerProvidedRoles -> selectOne(providedRole : OperationProvidedRole| providedRole.providedInterface__OperationProvidedRole.id = delegationConnectorProvidedInterface.id );
+				//get all RequiredRoles of the LoadBalancer and select these ones whose required interface equals the provided one as the calls are forwarded to the stereotyped and duplicated component
+				var loadBalancerAllRequiredRoles : Set(OperationRequiredRole) := loadBalancerAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity->selectByType(OperationRequiredRole);
+				var loadBalancerNeededRequiredRoles : Set(OperationRequiredRole) := loadBalancerAllRequiredRoles -> select(operationRequiredRole:OperationRequiredRole|operationRequiredRole.requiredInterface__OperationRequiredRole.id=delegationConnectorProvidedInterface.id);
+				//change the InnerProvidedRole and the AssemblyContext of the DelegationConnector to the LoadBalancer
+				delegationConnector.innerProvidedRole_ProvidedDelegationConnector := commonProvidedRoleOfDelegationConnectorAndLoadbalancer;
+				delegationConnector.assemblyContext_ProvidedDelegationConnector := loadBalancerAssemblyContext;
+				createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(delegationConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContextsAndLoadBalancedAssemblyContext);
+			}
+		}
+	};
+	//Connect the duplicated AssemblyContext with required AssemblyContexts 
+	if (loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity != null){
+					addRequiredRolesAssemblyConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet, system);
+					addRequiredRolesSystemDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+					addRequiredRolesAssemblyInfrastructureConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+				    addRequiredRolesInfrastructureDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+	};
+}
+
+
+helper createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(operationInterface:OperationInterface,loadBalancerAssemblyContext : AssemblyContext,loadBalancerNeededRequiredRoles : Set(OperationRequiredRole),duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext)){
+	var counter : Integer := 1;
+	loadBalancerNeededRequiredRoles -> forEach(loadBalancerNeededRequiredRole){
+		var system : System := loadBalancerAssemblyContext.parentStructure__AssemblyContext![System];
+		var targetAssemblyContext : AssemblyContext := duplicatedAssemblyContextsAndLoadBalancedAssemblyContext->at(counter);
+		var targetAssemblyContextProvidedRoles : Set(OperationProvidedRole) := targetAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(OperationProvidedRole);
+		var targetAssemblyContextProvidedRole : OperationProvidedRole := targetAssemblyContextProvidedRoles -> selectOne(op:OperationProvidedRole|op.providedInterface__OperationProvidedRole.id = operationInterface.id);
+		if(system.connectors__ComposedStructure[AssemblyConnector]->select(assemblyConnector | 
+																		assemblyConnector.providingAssemblyContext_AssemblyConnector.id = targetAssemblyContext.id 
+																		and assemblyConnector.requiringAssemblyContext_AssemblyConnector.id = loadBalancerAssemblyContext.id 
+																		and assemblyConnector.providedRole_AssemblyConnector.id = targetAssemblyContextProvidedRole.id
+																		and assemblyConnector.requiredRole_AssemblyConnector.id = loadBalancerNeededRequiredRole.id)->isEmpty()){
+			new AssemblyConnector(loadBalancerAssemblyContext,loadBalancerNeededRequiredRole,targetAssemblyContextProvidedRole,targetAssemblyContext);		
+		};				
+		targetAssemblyContextProvidedRoles := targetAssemblyContextProvidedRoles->excluding(targetAssemblyContextProvidedRole);
+		counter:=counter+1;
+	};
+}
+
+helper createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(infrastructureInterface:InfrastructureInterface,loadBalancerAssemblyContext : AssemblyContext,loadBalancerNeededRequiredRoles : Set(InfrastructureRequiredRole),duplicatedAssemblyContextsAndLoadBalancedAssemblyContext : OrderedSet(AssemblyContext)){
+	var counter : Integer := 1;
+	loadBalancerNeededRequiredRoles -> forEach(loadBalancerNeededRequiredRole){
+		var system : System := loadBalancerAssemblyContext.parentStructure__AssemblyContext![System];
+		var targetAssemblyContext : AssemblyContext := duplicatedAssemblyContextsAndLoadBalancedAssemblyContext->at(counter);
+		var targetAssemblyContextProvidedRoles : Set(InfrastructureProvidedRole) := targetAssemblyContext.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity->selectByType(InfrastructureProvidedRole);
+		var targetAssemblyContextProvidedRole : InfrastructureProvidedRole := targetAssemblyContextProvidedRoles -> selectOne(op:InfrastructureProvidedRole|op.providedInterface__InfrastructureProvidedRole.id = infrastructureInterface.id);
+		if(system.connectors__ComposedStructure[AssemblyInfrastructureConnector]->select(assemblyInfrastructureConnector | 
+																						assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector.id = targetAssemblyContext.id 
+																						and assemblyInfrastructureConnector.requiringAssemblyContext__AssemblyInfrastructureConnector.id = loadBalancerAssemblyContext.id
+																						and assemblyInfrastructureConnector.providedRole__AssemblyInfrastructureConnector.id = targetAssemblyContextProvidedRole.id
+																						and assemblyInfrastructureConnector.requiredRole__AssemblyInfrastructureConnector.id = loadBalancerNeededRequiredRole.id)->isEmpty()){
+			new AssemblyInfrastructureConnector(loadBalancerAssemblyContext,loadBalancerNeededRequiredRole,targetAssemblyContextProvidedRole,targetAssemblyContext);	
+		};					
+		targetAssemblyContextProvidedRoles := targetAssemblyContextProvidedRoles->excluding(targetAssemblyContextProvidedRole);
+		counter:=counter+1;
+	}
+}
+
+/**
+ * Creates an AssemblyConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * an OperationRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesAssemblyConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext), inout system:System){
+	var assemblyConnectors : Collection(AssemblyConnector) := system.connectors__ComposedStructure ->selectByType(AssemblyConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextConnectors : Collection(AssemblyConnector) := assemblyConnectors -> select(assemblyConnector : AssemblyConnector | loadBalancedRequiredRoles -> includes(assemblyConnector.requiredRole_AssemblyConnector));
+	requiredRoleLoadBalancedAssemblyContextConnectors -> forEach(assemblyConnector){
+		duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+			new AssemblyConnector(duplicatedAssemblyContext,assemblyConnector.requiredRole_AssemblyConnector,assemblyConnector.providedRole_AssemblyConnector,assemblyConnector.providingAssemblyContext_AssemblyConnector);
+			
+		}
+	};
+};
+
+/**
+ * Creates an AssemblyInfrastructureConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * an InfrastructureRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesAssemblyInfrastructureConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var system : System := loadBalancedAssemblyContext.parentStructure__AssemblyContext![System];
+	
+	var assemblyInfrastructureConnectors : Collection(AssemblyInfrastructureConnector) := system.connectors__ComposedStructure ->selectByType(AssemblyInfrastructureConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextConnectors : Collection(AssemblyInfrastructureConnector) := assemblyInfrastructureConnectors -> select(assemblyInfrastructureConnector : AssemblyInfrastructureConnector | loadBalancedRequiredRoles -> includes(assemblyInfrastructureConnector.requiredRole__AssemblyInfrastructureConnector));
+	requiredRoleLoadBalancedAssemblyContextConnectors -> forEach(assemblyConnector){
+		duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+			new AssemblyInfrastructureConnector(duplicatedAssemblyContext,assemblyConnector.requiredRole__AssemblyInfrastructureConnector,assemblyConnector.providedRole__AssemblyInfrastructureConnector,assemblyConnector.providingAssemblyContext__AssemblyInfrastructureConnector);
+			
+		}
+	};
+};
+
+/**
+ * Creates a RequiredSystemDelegationConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * the SystemOperationRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesSystemDelegationConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var system : System := loadBalancedAssemblyContext.parentStructure__AssemblyContext![System];
+	var delegationConnectors : Collection(RequiredDelegationConnector) := system.connectors__ComposedStructure -> selectByType(RequiredDelegationConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextDelegationConnectors : Collection(RequiredDelegationConnector) := delegationConnectors -> select(delegationConnector : RequiredDelegationConnector | loadBalancedRequiredRoles -> includes(delegationConnector.innerRequiredRole_RequiredDelegationConnector));
+	requiredRoleLoadBalancedAssemblyContextDelegationConnectors -> forEach(delegationConnector){
+	duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+		new RequiredDelegationConnector(duplicatedAssemblyContext,delegationConnector.innerRequiredRole_RequiredDelegationConnector,delegationConnector.outerRequiredRole_RequiredDelegationConnector);
+		}
+	};
+};
+
+/**
+ * Creates a RequiredInfrastructureDelegationConnector for each of the duplicated AssemblyContext in duplicatedAssemblyContextSet to 
+ * the InfrastructureRequiredRole specified by the loadBalancedAssemblyContext
+ */
+helper addRequiredRolesInfrastructureDelegationConnectors(loadBalancedAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext)){
+	var system : System := loadBalancedAssemblyContext.parentStructure__AssemblyContext![System];
+	var delegationConnectors : Collection(RequiredInfrastructureDelegationConnector) := system.connectors__ComposedStructure -> selectByType(RequiredInfrastructureDelegationConnector);
+	var loadBalancedRequiredRoles : Set(RequiredRole) := loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity;
+	var requiredRoleLoadBalancedAssemblyContextDelegationConnectors : Collection(RequiredInfrastructureDelegationConnector) := delegationConnectors -> select(delegationConnector : RequiredInfrastructureDelegationConnector | loadBalancedRequiredRoles -> includes(delegationConnector.innerRequiredRole__RequiredInfrastructureDelegationConnector));
+	requiredRoleLoadBalancedAssemblyContextDelegationConnectors -> forEach(delegationConnector){
+	duplicatedAssemblyContextSet ->forEach(duplicatedAssemblyContext){
+		new RequiredInfrastructureDelegationConnector(duplicatedAssemblyContext,delegationConnector.innerRequiredRole__RequiredInfrastructureDelegationConnector,delegationConnector.outerRequiredRole__RequiredInfrastructureDelegationConnector);
+		}
+	};
+};
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(providedDelegationConnector : ProvidedDelegationConnector) : AssemblyContext {
+	return providedDelegationConnector.assemblyContext_ProvidedDelegationConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(providedDelegationConnector : ProvidedInfrastructureDelegationConnector) : AssemblyContext {
+	return providedDelegationConnector.assemblyContext__ProvidedInfrastructureDelegationConnector;
+}
+
+/**
+ * Returns the requiring component of a given connector.
+ */
+query getRequiringAssemblyContext(assemblyConnector : AssemblyConnector) : AssemblyContext {
+	return assemblyConnector.requiringAssemblyContext_AssemblyConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(assemblyConnector : AssemblyConnector) : AssemblyContext {
+	return assemblyConnector.providingAssemblyContext_AssemblyConnector;
+}
+
+/**
+ * Returns the requiring component of a given connector.
+ */
+query getRequiringAssemblyContext(assemblyInfrastructureConnector : AssemblyInfrastructureConnector) : AssemblyContext {
+	return assemblyInfrastructureConnector.requiringAssemblyContext__AssemblyInfrastructureConnector;
+}
+
+/**
+ * Returns the providing component of a given connector.
+ */
+query getProvidingAssemblyContext(assemblyInfrastructureConnector : AssemblyInfrastructureConnector) : AssemblyContext {
+	return assemblyInfrastructureConnector.providingAssemblyContext__AssemblyInfrastructureConnector;
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/MainTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/MainTransformation.qvto
@@ -80,47 +80,8 @@ main() {
 			
 //		cfg.enactedPolicy.targetGroup[ServiceGroupCfg].map transformServiceGroup(cfg.enactedPolicy, elasticInfrastructureCfg);
 		
-		
-		
-		
 	}
 }
-//TODO:: Move in corresponding package
-mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy){
-	init {
-		var system:System :=  pcmSystem.rootObjects()[System]->any(true);
-		var assembliesDiff:Set(AssemblyContext) := ComputeDiffBasedOnAdjustmentType(enactedPolicy.adjustmentType, self.elements->size());
-	}
-	
-	
-}
-
-//TODO:: Move in corresponding package
-helper ComputeDiffBasedOnAdjustmentType(adjustment: AdjustmentType, currentSize:Integer) : Set(AssemblyContext){
-
-	var assembliesDiff : Set(AssemblyContext) := Set{};
-	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
-	log('Current number of assemblies ' + currentSize.toString());
-	
-	//TODO:Create Assemblies	
-	// in case 0 -> no change desired, in case > 0 -> add by creating new ones, in case < 0 -> select existing
-	if(desiredChange>0) {
-		var i : Integer := 0;
-		while (i < desiredChange) {
-			log('lets create');		
-//			var resourceContainer := Helper_createResourceContainerBasedOn(elasticInfrastructureCfg.unit);
-//			newAssemblies += resourceContainer;
-			i := i + 1;
-		};						
-	} else if (desiredChange<0){
-		desiredChange := desiredChange.abs();
-		var index : Integer := desiredChange.round();
-//		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
-	};	
-	return assembliesDiff;
-
-}
-
 
 helper preconditions(cfg:SPD_SEM::Configuration, resourceEnvironment:ResourceEnvironment, allocation:Allocation, system:System, repo:Repository, spdModel:SPD) {
     // check preconditions with respect to the Palladio models

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/MainTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/MainTransformation.qvto
@@ -1,0 +1,146 @@
+import pcm.helpers.Commons;
+import pcm.helpers.Constructors;
+import pcm.helpers.Wiring;
+import spd.bottomup.BottomUpTransformation;
+
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_USAGE uses 'http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2';
+modeltype PCM_FEATURE_CONF uses 'http://sdq.ipd.uka.de/FeatureConfig/2.0';
+modeltype PCM_FEATURE_MOD uses 'http://sdq.ipd.uka.de/FeatureModel/2.0';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+transformation MainTransformation(	inout pcmAllocation : PCM_ALLOC,
+									inout pcmSystem : PCM_SYS,
+									inout pcmResourceEnvironment : PCM_RES_ENV,
+									inout repository : PCM_REP,
+									in spd : SPD_MOD,
+									inout spdSemantic : SPD_SEM );
+									
+configuration property max_assemblies_per_host : Integer;
+
+
+main() {
+	var bottomUpTransformation : Transformation := new BottomUpTransformation(pcmAllocation, pcmSystem, pcmResourceEnvironment, repository, spd, spdSemantic);
+
+	//spd model
+	var spd : SPD = spd.objects()[SPD]->any(true);
+	log('Used SPD for transformation {name: '+ spd.entityName+'}');	
+	
+	//configuration
+	var cfg:SPD_SEM::Configuration = spdSemantic.objects()[SPD_SEM::Configuration]->any(true);
+	
+	// Palladio models
+	var resourceEnvironment : ResourceEnvironment = pcmResourceEnvironment.objects()[ResourceEnvironment]->any(true);
+	var system : System = pcmSystem.objects()[System]->any(true);
+	var allocation : Allocation = pcmAllocation.objects()[Allocation]->any(true);
+	var repository : Repository = repository.objects()[Repository]->any(true);
+	
+	preconditions(cfg, resourceEnvironment, allocation, system, repository, spd);
+	
+	
+	if(cfg.enactedPolicy.targetGroup.oclIsTypeOf(ElasticInfrastructure)){
+		// *********************
+		// Bottom-up Transformation
+		// *********************
+		bottomUpTransformation.transform();
+
+	} else if (cfg.enactedPolicy.targetGroup.oclIsTypeOf(ServiceGroup)){
+		// *********************
+		// Bidirectional Transformation
+		// *********************
+		
+		// *********************
+		// Transform Service Group
+		// *********************
+		
+		//TODO::fix add assembly ctx to the service group
+//		var serviceGroupCfg : ServiceGroupCfg := cfg.targetCfgs[ServiceGroupCfg]->any(svcGCfg | svcGCfg.unit.id = cfg.enactedPolicy.targetGroup.oclAsType(ServiceGroup).id);
+//		serviceGroupCfg.map transformServiceGroup(cfg.enactedPolicy);
+			
+//		cfg.enactedPolicy.targetGroup[ServiceGroupCfg].map transformServiceGroup(cfg.enactedPolicy, elasticInfrastructureCfg);
+		
+		
+		
+		
+	}
+}
+//TODO:: Move in corresponding package
+mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy){
+	init {
+		var system:System :=  pcmSystem.rootObjects()[System]->any(true);
+		var assembliesDiff:Set(AssemblyContext) := ComputeDiffBasedOnAdjustmentType(enactedPolicy.adjustmentType, self.elements->size());
+	}
+	
+	
+}
+
+//TODO:: Move in corresponding package
+helper ComputeDiffBasedOnAdjustmentType(adjustment: AdjustmentType, currentSize:Integer) : Set(AssemblyContext){
+
+	var assembliesDiff : Set(AssemblyContext) := Set{};
+	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
+	log('Current number of assemblies ' + currentSize.toString());
+	
+	//TODO:Create Assemblies	
+	// in case 0 -> no change desired, in case > 0 -> add by creating new ones, in case < 0 -> select existing
+	if(desiredChange>0) {
+		var i : Integer := 0;
+		while (i < desiredChange) {
+			log('lets create');		
+//			var resourceContainer := Helper_createResourceContainerBasedOn(elasticInfrastructureCfg.unit);
+//			newAssemblies += resourceContainer;
+			i := i + 1;
+		};						
+	} else if (desiredChange<0){
+		desiredChange := desiredChange.abs();
+		var index : Integer := desiredChange.round();
+//		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
+	};	
+	return assembliesDiff;
+
+}
+
+
+helper preconditions(cfg:SPD_SEM::Configuration, resourceEnvironment:ResourceEnvironment, allocation:Allocation, system:System, repo:Repository, spdModel:SPD) {
+    // check preconditions with respect to the Palladio models
+    assert fatal(cfg.resourceEnvironment=resourceEnvironment) 
+    	with log ('configuration points to a different resource environment');
+    assert fatal(cfg.allocation=allocation) 
+    	with log ('configuration points to a different allocation');
+    assert fatal(cfg.system=system) 
+    	with log ('configuration points to a different system');
+    assert fatal(cfg.repository=repo) 
+    	with log ('configuration points to a different repository');
+    assert fatal(cfg.spd=spdModel) 
+    	with log ('configuration points to a different spd');
+    
+    // at least one enacted policy
+    assert fatal(cfg.enactedPolicy<>null) 
+    	with log('non null enacted policy expected, terminating',cfg.enactedPolicy);
+    	
+   	// at least one elastic infrastructure configuration
+   	assert fatal(cfg.targetCfgs->any(c:TargetGroupCfg | c.oclIsTypeOf(ElasticInfrastructureCfg))<>null)
+   		with log('at least one ElasticInfrastructureCfg expected in the configuration')
+    
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
@@ -1,0 +1,68 @@
+import BottomUpTransformationInfrastructure;
+import BottomUpTransformationServices;
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+
+transformation BottomUpTransformation(	inout pcmAllocation : PCM_ALLOC,
+										inout pcmSystem : PCM_SYS,
+										inout pcmResourceEnvironment : PCM_RES_ENV,
+										inout repository : PCM_REP,
+										in spd : SPD_MOD,
+										inout spdSemantic : SPD_SEM);
+	
+										
+main() {
+		//spd model
+		var spd : SPD = spd.objects()[SPD]->any(true);
+		log('Used SPD for transformation {name: '+ spd.entityName+'}');	
+		//configuration
+		var cfg:SPD_SEM::Configuration = spdSemantic.objects()[SPD_SEM::Configuration]->any(true);
+		// Palladio models
+		var resourceEnvironment : ResourceEnvironment = pcmResourceEnvironment.objects()[ResourceEnvironment]->any(true);
+		var system : System = pcmSystem.objects()[System]->any(true);
+		var allocation : Allocation = pcmAllocation.objects()[Allocation]->any(true);
+		var repository : Repository = repository.objects()[Repository]->any(true);
+		
+		
+		// check preconditions
+		homogeneous_environment_assertion();
+		
+		// *********************
+		// Modify infrastructure
+		// *********************
+		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(true);
+		elasticInfrastructureCfg.map transformElasticInfrastructure(cfg.enactedPolicy);
+		resourceEnvironment.map modifyResourceEnvironment(elasticInfrastructureCfg);
+		
+		// *******************************
+		// Modify simulated service groups
+		// *******************************
+		cfg.targetCfgs[ServiceGroupCfg]->map transformServiceGroup(cfg.enactedPolicy, elasticInfrastructureCfg, system, allocation);
+}
+
+helper homogeneous_environment_assertion(){
+	
+}
+

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -1,0 +1,115 @@
+library BottomUpTransformationResourceEnvironment;
+
+import spd.common.AdjustmentCalculator;
+import pcm.helpers.Commons;
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+
+/**
+* The ElasticInfrastructureCfg is modified by transforming the elements and adding the policy to the enactedPolicies.
+*
+*/
+mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPolicy:ScalingPolicy){
+	init{
+		var resourceContainers:Set(ResourceContainer);
+		resourceContainers := AdjustElasticInfrastructure(enactedPolicy.adjustmentType,self);
+		var union:Set(ResourceContainer) := self.elements->union(resourceContainers);
+		var intersection:Set(ResourceContainer) := self.elements->intersection(resourceContainers);
+	}
+	elements := union - intersection;
+	enactedPolicies += enactedPolicy;
+}
+
+mapping inout ResourceEnvironment::modifyResourceEnvironment(elasticInfrastructureCfg:ElasticInfrastructureCfg){
+	resourceContainer_ResourceEnvironment := elasticInfrastructureCfg.elements;
+	linkingResources__ResourceEnvironment.map modifyLinkingResource(elasticInfrastructureCfg.elements);
+}
+
+mapping inout LinkingResource::modifyLinkingResource(resourceContainers:Set(ResourceContainer)){
+	connectedResourceContainers_LinkingResource := resourceContainers;
+}
+
+/**
+*
+* Semantic of adjusting an ElasticInfrastructure according to an AdjustmentType. 
+* This helper method does not modify the elasticInfrastructureCfg, but it yields the change that should occur through a set of resource containers.
+* 
+* In case the returned set contains elements that exist in the ElasticInfrastructureCfg.elements then either a scale in or no scale occurs.
+* In case the returned set contains new Resource Containers then the ElasticInfrastructureCfg then the ElasticInfrastructure scales out. 
+*
+* @param adjustment 				The type of adjustmend from the enacted policy from SPD.
+* @param elasticInfrastructureCfg	The elastic infrastructure configuration that is modified.
+* @return Set(ResourceContainer)	The set of resource containers to be added or removed from the ElasticInfrastructureCfg
+*/
+helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastructureCfg: ElasticInfrastructureCfg) : Set(ResourceContainer) {
+	var resourceContainers : Set(ResourceContainer) := Set{};
+	
+	
+	var currentSize : Integer = elasticInfrastructureCfg.resourceEnvironment.resourceContainer_ResourceEnvironment->size();
+	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
+	
+	log('Current number of containers ' + currentSize.toString());
+	
+	// in case 0 -> no change desired, in case > 0 -> add by creating new ones, in case < 0 -> select existing
+	if(desiredChange>0) {
+		var i : Integer := 0;
+		while (i < desiredChange) {
+			log('lets create');		
+			var resourceContainer := Helper_createResourceContainerBasedOn(elasticInfrastructureCfg.unit);
+			resourceContainers += resourceContainer;
+			i := i + 1;
+		};						
+	} else if (desiredChange<0){
+		desiredChange := desiredChange.abs();
+		var index : Integer := desiredChange.round();
+		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
+	};	
+	return resourceContainers;
+}
+
+
+/**
+ * Create a resource container replica based on the templateResourceContainer
+ *
+ * @param templateResourceContainer		The template resource container from which the processing specification is copied.
+ */
+helper Helper_createResourceContainerBasedOn(templateResourceContainer : ResourceContainer) : ResourceContainer {
+	
+	// duplicate resource container with same active resource specification
+	var newResContainer := object ResourceContainer {
+		entityName := templateResourceContainer.entityName+Commons_getUniqueElementNameSuffix();
+	};
+	var processingRate := object PCMRandomVariable {
+		specification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.processingRate_ProcessingResourceSpecification->any(true).specification;
+	};
+	
+	var newResourceSpec := object ProcessingResourceSpecification {
+		activeResourceType_ActiveResourceSpecification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification->any(true);
+		processingRate_ProcessingResourceSpecification := processingRate;
+		schedulingPolicy := templateResourceContainer.activeResourceSpecifications_ResourceContainer.schedulingPolicy->any(true);
+	};
+	newResContainer.activeResourceSpecifications_ResourceContainer += newResourceSpec;
+	return newResContainer;
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -2,6 +2,7 @@ library BottomUpTransformationResourceEnvironment;
 
 import spd.common.AdjustmentCalculator;
 import pcm.helpers.Commons;
+import pcm.helpers.Constructors;
 
 modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
 modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
@@ -77,7 +78,7 @@ helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastruc
 		var i : Integer := 0;
 		while (i < desiredChange) {
 			log('lets create');		
-			var resourceContainer := Helper_createResourceContainerBasedOn(elasticInfrastructureCfg.unit);
+			var resourceContainer := new ResourceContainer(elasticInfrastructureCfg.unit,Commons_getUniqueElementNameSuffix());
 			resourceContainers += resourceContainer;
 			i := i + 1;
 		};						
@@ -87,29 +88,4 @@ helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastruc
 		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
 	};	
 	return resourceContainers;
-}
-
-
-/**
- * Create a resource container replica based on the templateResourceContainer
- *
- * @param templateResourceContainer		The template resource container from which the processing specification is copied.
- */
-helper Helper_createResourceContainerBasedOn(templateResourceContainer : ResourceContainer) : ResourceContainer {
-	
-	// duplicate resource container with same active resource specification
-	var newResContainer := object ResourceContainer {
-		entityName := templateResourceContainer.entityName+Commons_getUniqueElementNameSuffix();
-	};
-	var processingRate := object PCMRandomVariable {
-		specification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.processingRate_ProcessingResourceSpecification->any(true).specification;
-	};
-	
-	var newResourceSpec := object ProcessingResourceSpecification {
-		activeResourceType_ActiveResourceSpecification := templateResourceContainer.activeResourceSpecifications_ResourceContainer.activeResourceType_ActiveResourceSpecification->any(true);
-		processingRate_ProcessingResourceSpecification := processingRate;
-		schedulingPolicy := templateResourceContainer.activeResourceSpecifications_ResourceContainer.schedulingPolicy->any(true);
-	};
-	newResContainer.activeResourceSpecifications_ResourceContainer += newResourceSpec;
-	return newResContainer;
 }

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
@@ -1,0 +1,167 @@
+library BottomUpTransformationServices;
+
+import pcm.helpers.Constructors;
+import pcm.helpers.Commons;
+import pcm.helpers.Wiring;
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+/*
+* A service group is transformed according to the number of resource containers that exist in the infrastructure. 
+* After the transformation of a ServiceGroupCfg the following hold:
+* * The number of elements in ServiceGroupCfg = Assembly Contexts Replica of the Unit = Number of Resource Containers = Number of AllocationCtxs of the Unit 
+* * The number of elements in ServiceGroupCfg = Number of ProbabilisiticBranchTransitions in LoadBalancer Seff
+* * Probability = 1 / The number of ProbabilisticBranchTransitions
+*/
+mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy, elasticInfraCfg:ElasticInfrastructureCfg, sys: System, alloc: Allocation){
+	//TODO:: add scaling down of the service group
+	init{
+		var newAssemblies:Set(AssemblyContext) := Set{};
+		var system:System :=  sys;
+		var allocation:Allocation := alloc;
+		
+		elasticInfraCfg.elements->forEach(resourceContainer){
+			if(allocation.allocationContexts_Allocation
+				->select(allocCtx | allocCtx.assemblyContext_AllocationContext.encapsulatedComponent__AssemblyContext=self.unit.encapsulatedComponent__AssemblyContext)
+				->select(allocCtx | allocCtx.resourceContainer_AllocationContext=resourceContainer)->size()=0){
+				log("no allocations for this assembly exist, lets create");
+				newAssemblies += Commons_createAssemblyContext(self.unit.encapsulatedComponent__AssemblyContext, self.unit,system, allocation, resourceContainer);
+			}
+		};		
+	}
+	
+	elements += newAssemblies;
+	if(newAssemblies->size()=0 and elasticInfraCfg.elements->size()<>self.elements->size()){
+		elements := elements->subOrderedSet(1,elasticInfraCfg.elements->size());
+		alloc.map modifyAllocationOnScaleIn(elements);
+		self.loadBalancingAssembly.encapsulatedComponent__AssemblyContext[BasicComponent].map modifyLoadBalancerOnScaleIn(self);
+		system.map modifySystemModelOnScaleIn(self);
+	} else {
+		self.loadBalancingAssembly.encapsulatedComponent__AssemblyContext[BasicComponent].map modifyLoadBalancer(self);
+		system.map modifySystemModel(self);
+	};
+	enactedPolicies += enactedPolicy;
+}
+
+mapping inout Allocation::modifyAllocationOnScaleIn(existingAssemblies:Set(AssemblyContext)){
+	init {
+		var allocationToPreserve:Set(AllocationContext) := Set{};	
+		existingAssemblies->forEach(assembly){
+			allocationToPreserve += self.allocationContexts_Allocation->select(allocCtx | allocCtx.assemblyContext_AllocationContext = assembly);
+		};
+		assert fatal(allocationToPreserve->size()=existingAssemblies->size()) with log('The number of assemblies that should exist and allocations that should exist does not match!');
+	}
+	allocationContexts_Allocation := allocationToPreserve;
+}
+
+mapping inout BasicComponent::modifyLoadBalancer(serviceGroupCfg:ServiceGroupCfg){
+	init{
+		var operationProvidedRole := serviceGroupCfg.unit.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity.oclAsType(OperationProvidedRole);
+		var operationInterface := operationProvidedRole.providedInterface__OperationProvidedRole;
+		var branchAction:BranchAction := self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF).steps_Behaviour->selectByType(BranchAction)->any(true);
+		var actualNumberOfRequiredRoles:Integer := self.requiredRoles_InterfaceRequiringEntity.oclAsType(OperationRequiredRole)->size();
+		var numberOfnewRoles:Integer :=  serviceGroupCfg.elements->size()-actualNumberOfRequiredRoles;
+		var newRoles:Set(OperationRequiredRole) := Set{};
+		var existingProvidedRole:OperationProvidedRole := serviceGroupCfg.unit.encapsulatedComponent__AssemblyContext[BasicComponent].providedRoles_InterfaceProvidingEntity[OperationProvidedRole]->any(true);
+		var counterRoles : Integer := 1;
+		while(counterRoles <= (numberOfnewRoles)){
+			log('operation required roles+needed:'+numberOfnewRoles.toString());
+				newRoles += new OperationRequiredRole(existingProvidedRole,counterRoles);
+				counterRoles := counterRoles+1;
+			};
+	}
+	
+	requiredRoles_InterfaceRequiringEntity += newRoles;
+	branchAction.map modifyBranchAction(serviceGroupCfg, operationInterface->any(true), newRoles);
+	branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+
+}
+
+mapping inout BasicComponent::modifyLoadBalancerOnScaleIn(serviceGroupCfg:ServiceGroupCfg){
+	init {
+		var branchAction:BranchAction := self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF).steps_Behaviour->selectByType(BranchAction)->any(true);
+		var sys:System := serviceGroupCfg.loadBalancingAssembly.parentStructure__AssemblyContext[System]->any(true);
+		var assemblyConnectors:Set(AssemblyConnector) := sys.connectors__ComposedStructure[AssemblyConnector]
+			->select(asmblConnector | asmblConnector.requiringAssemblyContext_AssemblyConnector.encapsulatedComponent__AssemblyContext = self)
+			->select(asmblConnector | serviceGroupCfg.elements->includes(asmblConnector.providingAssemblyContext_AssemblyConnector));
+		var rolesToPreserve:Bag(OperationRequiredRole) := assemblyConnectors.requiredRole_AssemblyConnector;
+	}
+	requiredRoles_InterfaceRequiringEntity := rolesToPreserve;
+	branchAction.map modifyBranchActionOnScaleIn(rolesToPreserve);
+	branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+	
+}
+
+mapping inout BranchAction::modifyBranchAction(serviceGroupCfg:ServiceGroupCfg, opInterface:OperationInterface, newRoles:Set(OperationRequiredRole)){
+	init {
+		var newProbabilisticBranches:Set(ProbabilisticBranchTransition) := Set{};
+		newRoles->forEach(role){
+			var operationSignature:OperationSignature := opInterface.signatures__OperationInterface->any(true); 
+			newProbabilisticBranches += new ProbabilisticBranchTransition(operationSignature,role);
+		}	
+	}
+	branches_Branch += newProbabilisticBranches;
+}
+
+mapping inout BranchAction::modifyBranchActionOnScaleIn(rolesPreserved:Bag(OperationRequiredRole)){
+	init {
+		var branchesToPreserve:Set(ProbabilisticBranchTransition) := self.branches_Branch[ProbabilisticBranchTransition]
+			->select(probBranchTransition | 
+				rolesPreserved->includes(probBranchTransition.branchBehaviour_BranchTransition.steps_Behaviour[ExternalCallAction]->any(true).role_ExternalService));
+	}
+	branches_Branch := branchesToPreserve;
+}
+
+mapping inout ProbabilisticBranchTransition::modifyProbability(replicas:Integer){
+	branchProbability := 1.0/replicas;
+}
+
+mapping inout System::modifySystemModelOnScaleIn(serviceCfg:ServiceGroupCfg){
+	init{
+		var assembliesToPreserve:Set(AssemblyContext) := self.assemblyContexts__ComposedStructure
+		->select(assembly | 
+			serviceCfg.elements->includes(assembly) 
+			or assembly.encapsulatedComponent__AssemblyContext<>serviceCfg.unit.encapsulatedComponent__AssemblyContext);
+			
+		var connectorsToRemove:Set(Connector) :=  self.connectors__ComposedStructure
+		->select(connector | 
+			connector.oclIsTypeOf(AssemblyConnector)
+			and serviceCfg.elements->excludes(connector.oclAsType(AssemblyConnector).providingAssemblyContext_AssemblyConnector));
+		var connectorsToPreserve:Set(Connector) := self.connectors__ComposedStructure - connectorsToRemove;
+	}
+	assemblyContexts__ComposedStructure := assembliesToPreserve;
+	connectors__ComposedStructure := connectorsToPreserve;
+}
+
+mapping inout System::modifySystemModel(serviceCfg:ServiceGroupCfg){
+	init {
+		var newAssemblies:OrderedSet(AssemblyContext) := OrderedSet{};
+		serviceCfg.elements->forEach(element){
+			if(self.connectors__ComposedStructure[AssemblyConnector]->exists(connector | connector.providingAssemblyContext_AssemblyConnector=element)=false){
+				newAssemblies += element;
+			}
+		}	
+	}
+	connectExistingLoadBalancerAndNewAssemblyContexts(serviceCfg.unit, serviceCfg.loadBalancingAssembly, newAssemblies, self);
+}

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
@@ -38,6 +38,7 @@ mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy
 	//TODO:: add scaling down of the service group
 	init{
 		var newAssemblies:Set(AssemblyContext) := Set{};
+		var assembliesToPreserve:Set(AssemblyContext) := Set{};
 		var system:System :=  sys;
 		var allocation:Allocation := alloc;
 		
@@ -52,8 +53,11 @@ mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy
 	}
 	
 	elements += newAssemblies;
-	if(newAssemblies->size()=0 and elasticInfraCfg.elements->size()<>self.elements->size()){
-		elements := elements->subOrderedSet(1,elasticInfraCfg.elements->size());
+	if(newAssemblies->size()=0 and elasticInfraCfg.elements->size() < self.elements->size()){
+		// subset elements to those for which an allocation points to a resource container that will exist after the transformation
+		elements := allocation.allocationContexts_Allocation->select(allocCtx | elasticInfraCfg.elements->includes(allocCtx.resourceContainer_AllocationContext) 
+		and elements->includes(allocCtx.assemblyContext_AllocationContext)).assemblyContext_AllocationContext;
+		
 		alloc.map modifyAllocationOnScaleIn(elements);
 		self.loadBalancingAssembly.encapsulatedComponent__AssemblyContext[BasicComponent].map modifyLoadBalancerOnScaleIn(self);
 		system.map modifySystemModelOnScaleIn(self);

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
@@ -1,0 +1,69 @@
+library AdjustmentCalculator;
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+/**
+* Interpretation of the AdjustmentType given the currentSize of the TargetGroup. 
+* The interpretation of the AdjustmentType given the currentSize of the target group yields a Ratio value that denotes the desiredChange in capacity for the target group.
+*
+* @param adjustment 	The type of adjustment being interpreted.
+* @param currentSize	The number of elements in the target group.
+* @return Real 			The desired change in capacity for the target group. 
+*/
+helper Interprete_adjustmentType(adjustment: AdjustmentType, currentSize: Integer) : Real {
+	var desiredChange : Real := 0;
+	switch {
+		case (adjustment.oclIsTypeOf(RelativeAdjustment)) {
+			var relativeAdjustment : RelativeAdjustment := adjustment.oclAsType(RelativeAdjustment);
+			desiredChange := caseRelativeAdjustmentType(relativeAdjustment, currentSize);
+		};
+		case (adjustment.oclIsTypeOf(AbsoluteAdjustment)) {	
+			var absoluteAdjustment : AbsoluteAdjustment := adjustment.oclAsType(AbsoluteAdjustment);
+			desiredChange := caseAbsoluteAdjustmentType(absoluteAdjustment, currentSize);
+		};
+		case (adjustment.oclIsTypeOf(StepAdjustment)){
+			var stepAdjustment : StepAdjustment := adjustment.oclAsType(StepAdjustment);
+			desiredChange := caseStepAdjustmentType(stepAdjustment, currentSize);
+		};
+	};
+	return desiredChange;
+}
+
+helper caseRelativeAdjustmentType(adjustment: RelativeAdjustment, currentSize: Integer) : Real {
+	var desiredChange : Real := 0;
+	var relativeAdjustment : RelativeAdjustment := adjustment.oclAsType(RelativeAdjustment);
+	var minAdjustmentValue : Integer := relativeAdjustment.minAdjustmentValue;
+	var percentageGrowthValue : Integer := relativeAdjustment.percentageGrowthValue;
+	log('A relative adjustment has been specified with min value: '+minAdjustmentValue.toString()+', and percentage growth '+percentageGrowthValue.toString());
+	
+	var desiredNumberOfNewResourceContainers:Real := currentSize * percentageGrowthValue/100.0;
+	
+	if(desiredNumberOfNewResourceContainers>0){
+		desiredChange := desiredNumberOfNewResourceContainers.max(minAdjustmentValue);
+	} else {
+		desiredChange := desiredNumberOfNewResourceContainers.min(minAdjustmentValue);
+	};
+	return desiredChange;
+}
+
+helper caseAbsoluteAdjustmentType(adjustment: AbsoluteAdjustment, currentSize: Integer) : Real {
+	var desiredChange : Real := 0;
+	var absoluteAdjustment : AbsoluteAdjustment := adjustment.oclAsType(AbsoluteAdjustment);
+	var goalValue := absoluteAdjustment.goalValue;
+	
+	assert fatal(goalValue>0) with log ('The specified goal value has to be greater then 0.'); 
+	desiredChange := goalValue - currentSize;
+	return desiredChange;
+}
+
+helper caseStepAdjustmentType(adjustment: StepAdjustment, currentSize: Integer) : Real {
+	var stepAdjustment : StepAdjustment := adjustment.oclAsType(StepAdjustment);
+	var stepSize : Integer := stepAdjustment.stepValue;
+	
+	return  stepSize;
+}
+
+

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformation.qvto
@@ -1,0 +1,71 @@
+import spd.common.AdjustmentCalculator;
+
+modeltype PCM uses 'http://palladiosimulator.org/PalladioComponentModel/5.2';
+modeltype PCM_ALLOC uses 'http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2';
+modeltype PCM_REP uses 'http://palladiosimulator.org/PalladioComponentModel/Repository/5.2';
+modeltype PCM_SEFF uses 'http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2';
+modeltype PCM_SYS uses 'http://palladiosimulator.org/PalladioComponentModel/System/5.2';
+modeltype PCM_RES_ENV uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2';
+modeltype PCM_RES_TYPE uses 'http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2';
+modeltype PCM_CORE uses 'http://palladiosimulator.org/PalladioComponentModel/Core/5.2';
+modeltype PCM_COMP uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2';
+modeltype PCM_ENTITY uses 'http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2';
+modeltype PCM_PARAM uses 'http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2';
+
+modeltype SPD_MOD uses 'http://palladiosimulator.org/ScalingPolicyDefinition/1.0';
+modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0';
+modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
+modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
+
+modeltype SPD_CON uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/1.0';
+modeltype SPD_CONP uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0';
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
+modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0';
+
+
+transformation TopDownTransformation(	inout pcmAllocation : PCM_ALLOC,
+										inout pcmSystem : PCM_SYS,
+										inout pcmResourceEnvironment : PCM_RES_ENV,
+										inout repository : PCM_REP,
+										in spd : SPD_MOD,
+										inout spdSemantic : SPD_SEM);
+	
+main(){
+	
+}
+
+
+mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy){
+	init {
+		var system:System :=  pcmSystem.rootObjects()[System]->any(true);
+		var assembliesDiff:Set(AssemblyContext) := ComputeDiffBasedOnAdjustmentType(enactedPolicy.adjustmentType, self.elements->size());
+	}
+	
+	
+}
+
+helper ComputeDiffBasedOnAdjustmentType(adjustment: AdjustmentType, currentSize:Integer) : Set(AssemblyContext){
+
+	var assembliesDiff : Set(AssemblyContext) := Set{};
+	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
+	log('Current number of assemblies ' + currentSize.toString());
+	
+	//TODO:Create Assemblies	
+	// in case 0 -> no change desired, in case > 0 -> add by creating new ones, in case < 0 -> select existing
+	if(desiredChange>0) {
+		var i : Integer := 0;
+		while (i < desiredChange) {
+			log('lets create');		
+//			var resourceContainer := Helper_createResourceContainerBasedOn(elasticInfrastructureCfg.unit);
+//			newAssemblies += resourceContainer;
+			i := i + 1;
+		};						
+	} else if (desiredChange<0){
+		desiredChange := desiredChange.abs();
+		var index : Integer := desiredChange.round();
+//		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
+	};	
+	return assembliesDiff;
+
+}


### PR DESCRIPTION
Through this PR, I intend to have QVTo transformations---that define the execution semantic behind SPD models---located together with the rest of SPD related code. 

**The intended use of the transformations script is threefold:** 

- First, one can execute a certain scaling policy on a Palladio model, to obtain a new Palladio model (scaled version) which then can be simulated. It can also be used to observe/debug quickly the effect of executing a scaling policy.  
-  Second, one can build a program that constructs a labelled transition system that explores all the possible states of the Palladio models under a set of active scaling policies where each transition represents one enacted scaling policy and verify certain properties/constraints. 
- Third, last but the most important one, we can use these scripts to transform the model during simulation in Slingshot. 

**Considerations:** 
- Right now the semantic is specified under the assumption that a policy has been already enacted.  The semantic does not specify how that enactment happen i.e., it does not define the semantic of the triggering. A possible extension would be to include the interpretation of RuntimeMeasurement models and to define also triggering. However, we would make the use cases one and two more difficult. 

**Structure of the code:** 
* archive [no need to look at], archive that eventually should be deleted
* pcm.helpers - here I reuse scripts that were written in the context of ATs and by other contributors in the Palladio context. Not all are relevant, I tread the scripts as a library to manipulate/construct Palladio models. 
* spd.common - here I define common aspects of the SPD interpretation. For example, you can look at the AdjustmentCalculator that defines the calculation based on an AdjustmentType given the currentSize of a targetGroup. 
* spd.bottomup - here I define (currently), the bottomup transformation of a Palladio model given policies that target an ElasticInfrastructure (which points to a ResourceEnvironment). It is named bottomup to reflect the semantic behind, that first the ResourceEnvironment is adjusted based on the AdjustmentType and then the services are replicated accordingly. 

**Future development and why to merge this partial semantic:**
The semantic is not fully complete, while it does not yet define the case in which policies target services and not infrastructure. However, I would argue that since it defines the semantic for the ElasticInfrastructure, we could use this code for testing and integration purposes with the simulator to have the initial use cases demonstratable.  

In the future then, an spd.topdown package would be added which would contain transformation scripts that first scale the services to the desired state and then adjust the infrastructure accordingly. 