### PR TITLE
add triggers/expectations and triggers/stimuli to urimap

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.m2m.qvt.oml.mmodel.urimap
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/.settings/org.eclipse.m2m.qvt.oml.mmodel.urimap
@@ -8,4 +8,6 @@
   <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Policy/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//constraints/policy"/>
   <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//constraints/target"/>
   <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinitionSemantic/1.0" targetURI="platform:/resource/org.palladiosimulator.spd.semantic/model/semantic.ecore#/"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/Stimuli/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//triggers/stimuli"/>
+  <mapping sourceURI="http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/Expectations/1.0" targetURI="platform:/resource/org.palladiosimulator.spd/model/SPD.ecore#//triggers/expectations"/>
 </uriMap:MappingContainer>


### PR DESCRIPTION
what the title says. 

for slingshot, this somehow does not matter. 
but when i tried to run the transformation as plain qvto, with a policy that has a trigger defined,  i got the following complaint: 
```
Transformation runner initialize
Failed to load model extent uri=platform:/resource/test-spd/My.spd
Package with uri 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/Stimuli/1.0' not found. (platform:/resource/test-spd/My.spd, 6, 52)
```

adding mappings for triggers/expectations and triggers/stimuli to the UriMap fixed the problem. 
