### PR TITLE
Fixing the consideration of only a single load balanced operation

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
@@ -52,9 +52,15 @@ main() {
 		// *********************
 		// Modify infrastructure
 		// *********************
+		var invariantResourceContainers:Set(ResourceContainer) := Set{};		
 		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(true);
+		resourceEnvironment.resourceContainer_ResourceEnvironment->forEach(rc){
+			if(elasticInfrastructureCfg.elements->excludes(rc)){
+				invariantResourceContainers += rc;		
+			};
+		};
 		elasticInfrastructureCfg.map transformElasticInfrastructure(cfg.enactedPolicy);
-		resourceEnvironment.map modifyResourceEnvironment(elasticInfrastructureCfg);
+		resourceEnvironment.map modifyResourceEnvironment(elasticInfrastructureCfg, invariantResourceContainers);
 		
 		// *******************************
 		// Modify simulated service groups

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -73,7 +73,7 @@ helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastruc
 	var resourceContainers : Set(ResourceContainer) := Set{};
 	
 	
-	var currentSize : Integer = elasticInfrastructureCfg.resourceEnvironment.resourceContainer_ResourceEnvironment->size();
+	var currentSize : Integer = elasticInfrastructureCfg.elements->size();
 	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
 	
 	log('Current number of containers ' + currentSize.toString());

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -43,9 +43,14 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 	enactedPolicies += enactedPolicy;
 }
 
-mapping inout ResourceEnvironment::modifyResourceEnvironment(elasticInfrastructureCfg:ElasticInfrastructureCfg){
-	resourceContainer_ResourceEnvironment := elasticInfrastructureCfg.elements;
-	linkingResources__ResourceEnvironment.map modifyLinkingResource(elasticInfrastructureCfg.elements);
+mapping inout ResourceEnvironment::modifyResourceEnvironment(elasticInfrastructureCfg:ElasticInfrastructureCfg, invariantResourceContainers:Set(ResourceContainer)){
+	init { 
+		var completeSetOfResourceContainers:Set(ResourceContainer) := Set{};
+		completeSetOfResourceContainers+=elasticInfrastructureCfg.elements;
+		completeSetOfResourceContainers+=invariantResourceContainers;
+	}
+	resourceContainer_ResourceEnvironment := completeSetOfResourceContainers;
+	linkingResources__ResourceEnvironment.map modifyLinkingResource(completeSetOfResourceContainers);
 }
 
 mapping inout LinkingResource::modifyLinkingResource(resourceContainers:Set(ResourceContainer)){

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
@@ -58,7 +58,7 @@ mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy
 		elements := allocation.allocationContexts_Allocation->select(allocCtx | elasticInfraCfg.elements->includes(allocCtx.resourceContainer_AllocationContext) 
 		and elements->includes(allocCtx.assemblyContext_AllocationContext)).assemblyContext_AllocationContext;
 		
-		alloc.map modifyAllocationOnScaleIn(elements);
+		alloc.map modifyAllocationOnScaleIn(elements, self.unit);
 		self.loadBalancingAssembly.encapsulatedComponent__AssemblyContext[BasicComponent].map modifyLoadBalancerOnScaleIn(self);
 		system.map modifySystemModelOnScaleIn(self);
 	} else {
@@ -68,15 +68,18 @@ mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy
 	enactedPolicies += enactedPolicy;
 }
 
-mapping inout Allocation::modifyAllocationOnScaleIn(existingAssemblies:Set(AssemblyContext)){
+mapping inout Allocation::modifyAllocationOnScaleIn(existingAssemblies:Set(AssemblyContext), unit:AssemblyContext){
 	init {
-		var allocationToPreserve:Set(AllocationContext) := Set{};	
+		var allocationToPreserve:Set(AllocationContext) := Set{};
+		var allAllocationsOfUnit:Set(AllocationContext) := self.allocationContexts_Allocation->select(allocCtxt | allocCtxt.assemblyContext_AllocationContext.encapsulatedComponent__AssemblyContext.id=unit.encapsulatedComponent__AssemblyContext.id);
 		existingAssemblies->forEach(assembly){
 			allocationToPreserve += self.allocationContexts_Allocation->select(allocCtx | allocCtx.assemblyContext_AllocationContext = assembly);
 		};
+		var allocationToRemove:Set(AllocationContext) := allAllocationsOfUnit - allocationToPreserve;
+		
 		assert fatal(allocationToPreserve->size()=existingAssemblies->size()) with log('The number of assemblies that should exist and allocations that should exist does not match!');
 	}
-	allocationContexts_Allocation := allocationToPreserve;
+	allocationContexts_Allocation := self.allocationContexts_Allocation - allocationToRemove;
 }
 
 mapping inout BasicComponent::modifyLoadBalancer(serviceGroupCfg:ServiceGroupCfg){

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationServices.qvto
@@ -83,7 +83,15 @@ mapping inout BasicComponent::modifyLoadBalancer(serviceGroupCfg:ServiceGroupCfg
 	init{
 		var operationProvidedRole := serviceGroupCfg.unit.encapsulatedComponent__AssemblyContext.providedRoles_InterfaceProvidingEntity.oclAsType(OperationProvidedRole);
 		var operationInterface := operationProvidedRole.providedInterface__OperationProvidedRole;
-		var branchAction:BranchAction := self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF).steps_Behaviour->selectByType(BranchAction)->any(true);
+		
+		var branchActions:Set(BranchAction) := Set{};
+		
+		self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF)->forEach(seff){
+			var branches:Set(BranchAction) := seff.steps_Behaviour->selectByType(BranchAction);
+			assert fatal(branches->size()=1) with log('Supports LoadBalancer with only BranchAction for RDSEFF');
+			branchActions += branches;
+		};
+		
 		var actualNumberOfRequiredRoles:Integer := self.requiredRoles_InterfaceRequiringEntity.oclAsType(OperationRequiredRole)->size();
 		var numberOfnewRoles:Integer :=  serviceGroupCfg.elements->size()-actualNumberOfRequiredRoles;
 		var newRoles:Set(OperationRequiredRole) := Set{};
@@ -97,14 +105,23 @@ mapping inout BasicComponent::modifyLoadBalancer(serviceGroupCfg:ServiceGroupCfg
 	}
 	
 	requiredRoles_InterfaceRequiringEntity += newRoles;
-	branchAction.map modifyBranchAction(serviceGroupCfg, operationInterface->any(true), newRoles);
-	branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+	branchActions-> modifyBranchAction(serviceGroupCfg, operationInterface->any(true), newRoles);
+	
+	branchActions->forEach(branchAction){	
+		branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+	}
 
 }
 
 mapping inout BasicComponent::modifyLoadBalancerOnScaleIn(serviceGroupCfg:ServiceGroupCfg){
 	init {
-		var branchAction:BranchAction := self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF).steps_Behaviour->selectByType(BranchAction)->any(true);
+		var branchActions:Set(BranchAction) := Set{};
+		
+		self.serviceEffectSpecifications__BasicComponent.oclAsType(ResourceDemandingSEFF)->forEach(seff){
+			var branches:Set(BranchAction) := seff.steps_Behaviour->selectByType(BranchAction);
+			assert fatal(branches->size()=1) with log('Supports LoadBalancer with only BranchAction for RDSEFF');
+			branchActions += branches;
+		};
 		var sys:System := serviceGroupCfg.loadBalancingAssembly.parentStructure__AssemblyContext[System]->any(true);
 		var assemblyConnectors:Set(AssemblyConnector) := sys.connectors__ComposedStructure[AssemblyConnector]
 			->select(asmblConnector | asmblConnector.requiringAssemblyContext_AssemblyConnector.encapsulatedComponent__AssemblyContext = self)
@@ -112,16 +129,20 @@ mapping inout BasicComponent::modifyLoadBalancerOnScaleIn(serviceGroupCfg:Servic
 		var rolesToPreserve:Bag(OperationRequiredRole) := assemblyConnectors.requiredRole_AssemblyConnector;
 	}
 	requiredRoles_InterfaceRequiringEntity := rolesToPreserve;
-	branchAction.map modifyBranchActionOnScaleIn(rolesToPreserve);
-	branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+	branchActions->map modifyBranchActionOnScaleIn(rolesToPreserve);
 	
+	branchActions->forEach(branchAction){	
+		branchAction.branches_Branch->select(b | b.oclIsTypeOf(ProbabilisticBranchTransition))[ProbabilisticBranchTransition]->map modifyProbability(requiredRoles_InterfaceRequiringEntity->size());
+	}
 }
+
+
 
 mapping inout BranchAction::modifyBranchAction(serviceGroupCfg:ServiceGroupCfg, opInterface:OperationInterface, newRoles:Set(OperationRequiredRole)){
 	init {
 		var newProbabilisticBranches:Set(ProbabilisticBranchTransition) := Set{};
 		newRoles->forEach(role){
-			var operationSignature:OperationSignature := opInterface.signatures__OperationInterface->any(true); 
+			var operationSignature:OperationSignature := self.branches_Branch.branchBehaviour_BranchTransition.steps_Behaviour[ExternalCallAction]->any(true).calledService_ExternalService;
 			newProbabilisticBranches += new ProbabilisticBranchTransition(operationSignature,role);
 		}	
 	}


### PR DESCRIPTION
Current behavior: 

The transformation does not consider the load balancing of multiple defined operations. 

New behavior:

The transformation modifies the branch actions in different Seffs accordingly when scaling out and scaling in. 

Tested with the test-spd model that is modified to have two operations. 