### PR TITLE
fixing the missing assembly connectors after scale out

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Wiring.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Wiring.qvto
@@ -15,7 +15,11 @@ modeltype PCM_RESOURCETYPE uses pcm::resourcetype('http://palladiosimulator.org/
 
 library Wiring();
 
-
+/**
+* Currently the implementation assumes that the LoadBalancer component is connected only through AssemblyConnectors with the assemblies that are elements of a service group.
+*
+* @author klinakuf
+*/
 helper connectExistingLoadBalancerAndNewAssemblyContexts(loadBalancedAssemblyContext : AssemblyContext, loadBalancerAssemblyContext : AssemblyContext, duplicatedAssemblyContextSet : OrderedSet(AssemblyContext), inout system:System){
 	var duplicatedAssemblyContexts : OrderedSet(AssemblyContext):= duplicatedAssemblyContextSet;
 	var connectors : Set(Connector) := system.connectors__ComposedStructure;
@@ -37,6 +41,13 @@ helper connectExistingLoadBalancerAndNewAssemblyContexts(loadBalancedAssemblyCon
 	loadBalancerNeededRequiredRoles := loadBalancerAllRequiredRoles - loadBalancerFilledRequiredRoles;
 	createAssemblyConnectorsBetweenLoadbalancerAndLoadbalancedAssemblyContexts(assemblyConnectorProvidedInterface,loadBalancerAssemblyContext,loadBalancerNeededRequiredRoles,duplicatedAssemblyContexts);
 	
+	//Connect the duplicated AssemblyContext with required AssemblyContexts 
+	if (loadBalancedAssemblyContext.encapsulatedComponent__AssemblyContext.requiredRoles_InterfaceRequiringEntity != null){
+					addRequiredRolesAssemblyConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet, system);
+					addRequiredRolesSystemDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+					addRequiredRolesAssemblyInfrastructureConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+				    addRequiredRolesInfrastructureDelegationConnectors(loadBalancedAssemblyContext, duplicatedAssemblyContextSet);
+	};
 }
 
 


### PR DESCRIPTION
Behavior before: 

The elements part of a service group were not connected to the dependent assemblies through appropriate connectors. 

Behavior now: 

Wiring is modified so that the elements get connected. I tested this with a small example where the element of the target group depends on a database assembly. After the replication, all the elements are connected to the same database assembly. Would be nice if the reviewer looks at it also for a different example. 