### PR TITLE
fixing scaling in of infrastructure

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -34,12 +34,22 @@ modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSema
 */
 mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPolicy:ScalingPolicy){
 	init{
-		var resourceContainers:Set(ResourceContainer);
+		var resourceContainers:OrderedSet(ResourceContainer);
+		var newElements:OrderedSet(ResourceContainer);
 		resourceContainers := AdjustElasticInfrastructure(enactedPolicy.adjustmentType,self);
-		var union:Set(ResourceContainer) := self.elements->union(resourceContainers);
 		var intersection:Set(ResourceContainer) := self.elements->intersection(resourceContainers);
+		if(intersection->size()=0){
+			//append all rcs to elements
+			newElements := self.elements;
+			resourceContainers->forEach(rc){
+				newElements := newElements->append(rc);
+			}
+		} else {
+			newElements := resourceContainers;
+		}
 	}
-	elements := union - intersection;
+	
+	elements := newElements;
 	enactedPolicies += enactedPolicy;
 }
 
@@ -69,8 +79,8 @@ mapping inout LinkingResource::modifyLinkingResource(resourceContainers:Set(Reso
 * @param elasticInfrastructureCfg	The elastic infrastructure configuration that is modified.
 * @return Set(ResourceContainer)	The set of resource containers to be added or removed from the ElasticInfrastructureCfg
 */
-helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastructureCfg: ElasticInfrastructureCfg) : Set(ResourceContainer) {
-	var resourceContainers : Set(ResourceContainer) := Set{};
+helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastructureCfg: ElasticInfrastructureCfg) : OrderedSet(ResourceContainer) {
+	var resourceContainers : OrderedSet(ResourceContainer) := OrderedSet{};
 	
 	
 	var currentSize : Integer = elasticInfrastructureCfg.elements->size();
@@ -102,7 +112,7 @@ helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastruc
 		*/
 		
 		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
-		assert fatal(resourceContainers->excludes(elasticInfrastructureCfg.unit)) with log('The unit is not the first element in the elements configuration, hence it would be destroyed!');
+		assert fatal(resourceContainers->includes(elasticInfrastructureCfg.unit)) with log('The unit is not the first element in the elements configuration, hence it would be destroyed!');
 	};	
 	return resourceContainers;
 }

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -89,8 +89,20 @@ helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastruc
 		};						
 	} else if (desiredChange<0){
 		desiredChange := desiredChange.abs();
-		var index : Integer := desiredChange.round();
+		var minimalNumberOfResourceContainers : Integer := 1;
+		var index : Integer := minimalNumberOfResourceContainers.max(elasticInfrastructureCfg.elements->size()-desiredChange.round());
+		
+		/*
+		* subOrderedSet contract:
+		* pre : 1 <= lower
+		* pre : lower <= upper
+		* pre : upper <= self->size()
+		* post: result->size() = upper -lower + 1
+		* post: Sequence{lower..upper}->forAll( index | result->at(index - lower + 1) = self->at(index))
+		*/
+		
 		resourceContainers += elasticInfrastructureCfg.elements->subOrderedSet(1, index);
+		assert fatal(resourceContainers->excludes(elasticInfrastructureCfg.unit)) with log('The unit is not the first element in the elements configuration, hence it would be destroyed!');
 	};	
 	return resourceContainers;
 }


### PR DESCRIPTION
This PR fixes the wrong calculation for scaling in. It should resolve issue #10 and also other behaviors encountered during simulation. 

I added in the code also the pre and post conditions of the subOrderedSet so that it remains clear what it does. In addition I added an assert fatal in case the computed resourceContainers after scaling in exclude the unit. 