### PR TITLE
Add to the metamodel the unitAssembly for service group

### DIFF
--- a/bundles/org.palladiosimulator.spd.edit/plugin.properties
+++ b/bundles/org.palladiosimulator.spd.edit/plugin.properties
@@ -118,3 +118,4 @@ _UI_TrendPattern_Increasing_literal = Increasing
 _UI_TrendPattern_Decreasing_literal = Decreasing
 _UI_TrendPattern_NonIncreasing_literal = NonIncreasing
 _UI_TrendPattern_NonDecreasing_literal = NonDecreasing
+_UI_ServiceGroup_unitAssembly_feature = Unit Assembly

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/AbsoluteAdjustmentItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/AbsoluteAdjustmentItemProvider.java
@@ -63,7 +63,7 @@ public class AbsoluteAdjustmentItemProvider extends AdjustmentTypeItemProvider {
 				AdjustmentsPackage.Literals.ABSOLUTE_ADJUSTMENT__GOAL_VALUE, true, false, false,
 				ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE, null, null));
 	}
-	
+
 	/**
 	 * Returns adjustment icon.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/AdjustmentTypeItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/AdjustmentTypeItemProvider.java
@@ -61,7 +61,7 @@ public class AdjustmentTypeItemProvider extends ItemProviderAdapter implements I
 	public String getText(Object object) {
 		return getString("_UI_AdjustmentType_type");
 	}
-	
+
 	/**
 	 * Returns adjustment icon pointing upwards for all adjustment types.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/RelativeAdjustmentItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/RelativeAdjustmentItemProvider.java
@@ -80,10 +80,10 @@ public class RelativeAdjustmentItemProvider extends AdjustmentTypeItemProvider {
 						AdjustmentsPackage.Literals.RELATIVE_ADJUSTMENT__MIN_ADJUSTMENT_VALUE, true, false, false,
 						ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE, null, null));
 	}
-	
+
 	/**
 	 * Overrides in case of RelativeAdjustment to show the icon pointing down when the value is negative.
-	 * 
+	 *
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated NOT
@@ -91,12 +91,11 @@ public class RelativeAdjustmentItemProvider extends AdjustmentTypeItemProvider {
 	@Override
 	public Object getImage(Object object) {
 		RelativeAdjustment relativeAdjustment = (RelativeAdjustment) object;
-		if(relativeAdjustment.getPercentageGrowthValue()<0) {
+		if (relativeAdjustment.getPercentageGrowthValue() < 0) {
 			return overlayImage(object, getResourceLocator().getImage("full/spdicons16/adjustment-down.png"));
 		}
 		return super.getImage(object);
 	}
-
 
 	/**
 	 * This returns the label text for the adapted class.

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/StepAdjustmentItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/adjustments/provider/StepAdjustmentItemProvider.java
@@ -63,10 +63,10 @@ public class StepAdjustmentItemProvider extends AdjustmentTypeItemProvider {
 						AdjustmentsPackage.Literals.STEP_ADJUSTMENT__STEP_VALUE, true, false, false,
 						ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE, null, null));
 	}
-	
+
 	/**
 	 * Overrides in case of StepAdjustment to show the icon pointing down when the step value is negative.
-	 * 
+	 *
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated NOT
@@ -74,7 +74,7 @@ public class StepAdjustmentItemProvider extends AdjustmentTypeItemProvider {
 	@Override
 	public Object getImage(Object object) {
 		StepAdjustment stepAdjustment = (StepAdjustment) object;
-		if(stepAdjustment.getStepValue()<0) {
+		if (stepAdjustment.getStepValue() < 0) {
 			return overlayImage(object, getResourceLocator().getImage("full/spdicons16/adjustment-down.png"));
 		}
 		return super.getImage(object);

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/CompetingConsumersGroupItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/CompetingConsumersGroupItemProvider.java
@@ -42,6 +42,7 @@ public class CompetingConsumersGroupItemProvider extends TargetGroupItemProvider
 		}
 		return itemPropertyDescriptors;
 	}
+
 	/*
 	 * This overrides and reuses the icon for a TargetGroup.
 	 * <!-- begin-user-doc -->
@@ -52,7 +53,7 @@ public class CompetingConsumersGroupItemProvider extends TargetGroupItemProvider
 	public Object getImage(Object object) {
 		return super.getImage(object);
 	}
-	
+
 	/**
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ElasticInfrastructureItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ElasticInfrastructureItemProvider.java
@@ -72,7 +72,7 @@ public class ElasticInfrastructureItemProvider extends TargetGroupItemProvider {
 	public Object getImage(Object object) {
 		return super.getImage(object);
 	}
-	
+
 	/**
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ServiceGroupItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ServiceGroupItemProvider.java
@@ -8,8 +8,10 @@ import java.util.List;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.palladiosimulator.spd.targets.ServiceGroup;
+import org.palladiosimulator.spd.targets.TargetsPackage;
 
 /**
  * This is the item provider adapter for a {@link org.palladiosimulator.spd.targets.ServiceGroup} object.
@@ -39,10 +41,26 @@ public class ServiceGroupItemProvider extends TargetGroupItemProvider {
 		if (itemPropertyDescriptors == null) {
 			super.getPropertyDescriptors(object);
 
+			addUnitAssemblyPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
-	
+
+	/**
+	 * This adds a property descriptor for the Unit Assembly feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addUnitAssemblyPropertyDescriptor(Object object) {
+		itemPropertyDescriptors
+				.add(createItemPropertyDescriptor(((ComposeableAdapterFactory) adapterFactory).getRootAdapterFactory(),
+						getResourceLocator(), getString("_UI_ServiceGroup_unitAssembly_feature"),
+						getString("_UI_PropertyDescriptor_description", "_UI_ServiceGroup_unitAssembly_feature",
+								"_UI_ServiceGroup_type"),
+						TargetsPackage.Literals.SERVICE_GROUP__UNIT_ASSEMBLY, true, false, true, null, null, null));
+	}
+
 	/*
 	 * This overrides and reuses the icon for a TargetGroup.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/TargetGroupItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/TargetGroupItemProvider.java
@@ -92,7 +92,7 @@ public class TargetGroupItemProvider extends EntityItemProvider {
 		return label == null || label.length() == 0 ? getString("_UI_TargetGroup_type")
 				: getString("_UI_TargetGroup_type") + " " + label;
 	}
-	
+
 	/**
 	 * This returns the icon for a target group.
 	 * <!-- begin-user-doc -->
@@ -104,8 +104,6 @@ public class TargetGroupItemProvider extends EntityItemProvider {
 		return overlayImage(object, getResourceLocator().getImage("full/spdicons16/target-icon.png"));
 	}
 
-
-	
 	/**
 	 * This handles model notifications by calling {@link #updateChildren} to update any cached
 	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/ComposedTriggerItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/ComposedTriggerItemProvider.java
@@ -106,6 +106,7 @@ public class ComposedTriggerItemProvider extends ScalingTriggerItemProvider {
 	public Object getImage(Object object) {
 		return super.getImage(object);
 	}
+
 	/**
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/ScalingTriggerItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/ScalingTriggerItemProvider.java
@@ -59,7 +59,7 @@ public class ScalingTriggerItemProvider extends IdentifierItemProvider {
 		return label == null || label.length() == 0 ? getString("_UI_ScalingTrigger_type")
 				: getString("_UI_ScalingTrigger_type") + " " + label;
 	}
-	
+
 	/**
 	 * This returns the icon for the scaling trigger.
 	 * <!-- begin-user-doc -->
@@ -70,7 +70,6 @@ public class ScalingTriggerItemProvider extends IdentifierItemProvider {
 	public Object getImage(Object object) {
 		return overlayImage(object, getResourceLocator().getImage("full/spdicons16/trigger-icon.png"));
 	}
-
 
 	/**
 	 * This handles model notifications by calling {@link #updateChildren} to update any cached

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/SimpleFireOnTrendItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/SimpleFireOnTrendItemProvider.java
@@ -53,6 +53,7 @@ public class SimpleFireOnTrendItemProvider extends BaseTriggerItemProvider {
 	public Object getImage(Object object) {
 		return super.getImage(object);
 	}
+
 	/**
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/SimpleFireOnValueItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/triggers/provider/SimpleFireOnValueItemProvider.java
@@ -74,6 +74,7 @@ public class SimpleFireOnValueItemProvider extends BaseTriggerItemProvider {
 	public Object getImage(Object object) {
 		return super.getImage(object);
 	}
+
 	/**
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->

--- a/bundles/org.palladiosimulator.spd/model/SPD.ecore
+++ b/bundles/org.palladiosimulator.spd/model/SPD.ecore
@@ -48,7 +48,13 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="PCM_ResourceEnvironment"
           eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceEnvironment"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="ServiceGroup" eSuperTypes="#//targets/TargetGroup"/>
+    <eClassifiers xsi:type="ecore:EClass" name="ServiceGroup" eSuperTypes="#//targets/TargetGroup">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="unitAssembly" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="The unitAssembly is used to point to the ServiceGroup in PCM. It is used also for disinguishing between different service groups. A prerequisite is that the unit assembly is already connected in a Service Group structure in PCM. "/>
+        </eAnnotations>
+      </eStructuralFeatures>
+    </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="CompetingConsumersGroup" eSuperTypes="#//targets/TargetGroup"/>
   </eSubpackages>
   <eSubpackages name="adjustments" nsURI="http://palladiosimulator.org/ScalingPolicyDefinition/Adjustments/1.0"

--- a/bundles/org.palladiosimulator.spd/model/SPD.genmodel
+++ b/bundles/org.palladiosimulator.spd/model/SPD.genmodel
@@ -31,7 +31,10 @@
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference SPD.ecore#//targets/ElasticInfrastructure/PCM_ResourceEnvironment"/>
       </genClasses>
-      <genClasses ecoreClass="SPD.ecore#//targets/ServiceGroup" labelFeature="platform:/plugin/org.palladiosimulator.pcm/model/pcm.genmodel#//pcm/core/entity/NamedElement/entityName"/>
+      <genClasses ecoreClass="SPD.ecore#//targets/ServiceGroup" labelFeature="platform:/plugin/org.palladiosimulator.pcm/model/pcm.genmodel#//pcm/core/entity/NamedElement/entityName">
+        <genFeatures notify="false" createChild="false" propertySortChoices="true"
+            ecoreFeature="ecore:EReference SPD.ecore#//targets/ServiceGroup/unitAssembly"/>
+      </genClasses>
       <genClasses ecoreClass="SPD.ecore#//targets/CompetingConsumersGroup" labelFeature="platform:/plugin/org.palladiosimulator.pcm/model/pcm.genmodel#//pcm/core/entity/NamedElement/entityName"/>
     </nestedGenPackages>
     <nestedGenPackages prefix="Adjustments" basePackage="org.palladiosimulator.spd"

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ServiceGroup.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ServiceGroup.java
@@ -3,15 +3,48 @@
  */
 package org.palladiosimulator.spd.targets;
 
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+
 /**
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Service Group</b></em>'.
  * <!-- end-user-doc -->
  *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.palladiosimulator.spd.targets.ServiceGroup#getUnitAssembly <em>Unit Assembly</em>}</li>
+ * </ul>
  *
  * @see org.palladiosimulator.spd.targets.TargetsPackage#getServiceGroup()
  * @model
  * @generated
  */
 public interface ServiceGroup extends TargetGroup {
+
+	/**
+	 * Returns the value of the '<em><b>Unit Assembly</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The unitAssembly is used to point to the ServiceGroup in PCM. It is used also for disinguishing between different service groups. A prerequisite is that the unit assembly is already connected in a Service Group structure in PCM.
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Unit Assembly</em>' reference.
+	 * @see #setUnitAssembly(AssemblyContext)
+	 * @see org.palladiosimulator.spd.targets.TargetsPackage#getServiceGroup_UnitAssembly()
+	 * @model
+	 * @generated
+	 */
+	AssemblyContext getUnitAssembly();
+
+	/**
+	 * Sets the value of the '{@link org.palladiosimulator.spd.targets.ServiceGroup#getUnitAssembly <em>Unit Assembly</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Unit Assembly</em>' reference.
+	 * @see #getUnitAssembly()
+	 * @generated
+	 */
+	void setUnitAssembly(AssemblyContext value);
 } // ServiceGroup

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/TargetsPackage.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/TargetsPackage.java
@@ -195,13 +195,22 @@ public interface TargetsPackage extends EPackage {
 	int SERVICE_GROUP__TARGET_CONSTRAINTS = TARGET_GROUP__TARGET_CONSTRAINTS;
 
 	/**
+	 * The feature id for the '<em><b>Unit Assembly</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SERVICE_GROUP__UNIT_ASSEMBLY = TARGET_GROUP_FEATURE_COUNT + 0;
+
+	/**
 	 * The number of structural features of the '<em>Service Group</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int SERVICE_GROUP_FEATURE_COUNT = TARGET_GROUP_FEATURE_COUNT + 0;
+	int SERVICE_GROUP_FEATURE_COUNT = TARGET_GROUP_FEATURE_COUNT + 1;
 
 	/**
 	 * The meta object id for the '{@link org.palladiosimulator.spd.targets.impl.CompetingConsumersGroupImpl <em>Competing Consumers Group</em>}' class.
@@ -302,6 +311,17 @@ public interface TargetsPackage extends EPackage {
 	EClass getServiceGroup();
 
 	/**
+	 * Returns the meta object for the reference '{@link org.palladiosimulator.spd.targets.ServiceGroup#getUnitAssembly <em>Unit Assembly</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the reference '<em>Unit Assembly</em>'.
+	 * @see org.palladiosimulator.spd.targets.ServiceGroup#getUnitAssembly()
+	 * @see #getServiceGroup()
+	 * @generated
+	 */
+	EReference getServiceGroup_UnitAssembly();
+
+	/**
 	 * Returns the meta object for class '{@link org.palladiosimulator.spd.targets.CompetingConsumersGroup <em>Competing Consumers Group</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -379,6 +399,14 @@ public interface TargetsPackage extends EPackage {
 		 * @generated
 		 */
 		EClass SERVICE_GROUP = eINSTANCE.getServiceGroup();
+
+		/**
+		 * The meta object literal for the '<em><b>Unit Assembly</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference SERVICE_GROUP__UNIT_ASSEMBLY = eINSTANCE.getServiceGroup_UnitAssembly();
 
 		/**
 		 * The meta object literal for the '{@link org.palladiosimulator.spd.targets.impl.CompetingConsumersGroupImpl <em>Competing Consumers Group</em>}' class.

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ServiceGroupImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ServiceGroupImpl.java
@@ -4,6 +4,7 @@
 package org.palladiosimulator.spd.targets.impl;
 
 import org.eclipse.emf.ecore.EClass;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.spd.targets.ServiceGroup;
 import org.palladiosimulator.spd.targets.TargetsPackage;
 
@@ -11,6 +12,12 @@ import org.palladiosimulator.spd.targets.TargetsPackage;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Service Group</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.palladiosimulator.spd.targets.impl.ServiceGroupImpl#getUnitAssembly <em>Unit Assembly</em>}</li>
+ * </ul>
  *
  * @generated
  */
@@ -32,6 +39,98 @@ public class ServiceGroupImpl extends TargetGroupImpl implements ServiceGroup {
 	@Override
 	protected EClass eStaticClass() {
 		return TargetsPackage.Literals.SERVICE_GROUP;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public AssemblyContext getUnitAssembly() {
+		return (AssemblyContext) eDynamicGet(TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY,
+				TargetsPackage.Literals.SERVICE_GROUP__UNIT_ASSEMBLY, true, true);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public AssemblyContext basicGetUnitAssembly() {
+		return (AssemblyContext) eDynamicGet(TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY,
+				TargetsPackage.Literals.SERVICE_GROUP__UNIT_ASSEMBLY, false, true);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setUnitAssembly(AssemblyContext newUnitAssembly) {
+		eDynamicSet(TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY, TargetsPackage.Literals.SERVICE_GROUP__UNIT_ASSEMBLY,
+				newUnitAssembly);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+		case TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY:
+			if (resolve)
+				return getUnitAssembly();
+			return basicGetUnitAssembly();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+		case TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY:
+			setUnitAssembly((AssemblyContext) newValue);
+			return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+		case TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY:
+			setUnitAssembly((AssemblyContext) null);
+			return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+		case TargetsPackage.SERVICE_GROUP__UNIT_ASSEMBLY:
+			return basicGetUnitAssembly() != null;
+		}
+		return super.eIsSet(featureID);
 	}
 
 } //ServiceGroupImpl

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
@@ -9,6 +9,7 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 import org.palladiosimulator.pcm.PcmPackage;
+import org.palladiosimulator.pcm.core.composition.CompositionPackage;
 import org.palladiosimulator.pcm.core.entity.EntityPackage;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentPackage;
 import org.palladiosimulator.spd.SpdPackage;
@@ -251,6 +252,16 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 	 * @generated
 	 */
 	@Override
+	public EReference getServiceGroup_UnitAssembly() {
+		return (EReference) serviceGroupEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EClass getCompetingConsumersGroup() {
 		return competingConsumersGroupEClass;
 	}
@@ -292,6 +303,7 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 		createEReference(elasticInfrastructureEClass, ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT);
 
 		serviceGroupEClass = createEClass(SERVICE_GROUP);
+		createEReference(serviceGroupEClass, SERVICE_GROUP__UNIT_ASSEMBLY);
 
 		competingConsumersGroupEClass = createEClass(COMPETING_CONSUMERS_GROUP);
 	}
@@ -325,6 +337,8 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 		TargetPackage theTargetPackage = (TargetPackage) EPackage.Registry.INSTANCE.getEPackage(TargetPackage.eNS_URI);
 		ResourceenvironmentPackage theResourceenvironmentPackage = (ResourceenvironmentPackage) EPackage.Registry.INSTANCE
 				.getEPackage(ResourceenvironmentPackage.eNS_URI);
+		CompositionPackage theCompositionPackage = (CompositionPackage) EPackage.Registry.INSTANCE
+				.getEPackage(CompositionPackage.eNS_URI);
 
 		// Create type parameters
 
@@ -352,6 +366,9 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 
 		initEClass(serviceGroupEClass, ServiceGroup.class, "ServiceGroup", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getServiceGroup_UnitAssembly(), theCompositionPackage.getAssemblyContext(), null, "unitAssembly",
+				null, 0, 1, ServiceGroup.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(competingConsumersGroupEClass, CompetingConsumersGroup.class, "CompetingConsumersGroup",
 				!IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);


### PR DESCRIPTION
Before when defining target groups for the ServiceGroup it was not possible to reference an existing assembly. Now there is the unitAssembly which should point to the unit assembly for a service target group. 

This is neccessary also for the semantic to work. Right now, it picks just a single one and does the transformation based on that. 

So this PR is a prereuqisite for merging #13.    