### PR TITLE
Interpreting Group Size Constraints for Target Groups 

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -36,7 +36,7 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 	init{
 		var resourceContainers:OrderedSet(ResourceContainer);
 		var newElements:OrderedSet(ResourceContainer);
-		resourceContainers := AdjustElasticInfrastructure(enactedPolicy.adjustmentType,self);
+		resourceContainers := AdjustElasticInfrastructure(enactedPolicy,self);
 		var intersection:Set(ResourceContainer) := self.elements->intersection(resourceContainers);
 		if(intersection->size()=0){
 			//append all rcs to elements
@@ -65,12 +65,18 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 * @param elasticInfrastructureCfg	The elastic infrastructure configuration that is modified.
 * @return Set(ResourceContainer)	The set of resource containers to be added or removed from the ElasticInfrastructureCfg
 */
-helper AdjustElasticInfrastructure(adjustment: AdjustmentType, elasticInfrastructureCfg: ElasticInfrastructureCfg) : OrderedSet(ResourceContainer) {
+helper AdjustElasticInfrastructure(policy: ScalingPolicy, elasticInfrastructureCfg: ElasticInfrastructureCfg) : OrderedSet(ResourceContainer) {
 	var resourceContainers : OrderedSet(ResourceContainer) := OrderedSet{};
 	
+	var adjustment: AdjustmentType := policy.adjustmentType;
 	
 	var currentSize : Integer = elasticInfrastructureCfg.elements->size();
 	var desiredChange : Real := Interprete_adjustmentType(adjustment, currentSize);
+	
+	if(policy.targetGroup.targetConstraints[TargetGroupSizeConstraint]->notEmpty()){
+		desiredChange := Interprete_GroupSizeConstraints(elasticInfrastructureCfg.elements->size(),desiredChange,policy.targetGroup.targetConstraints[TargetGroupSizeConstraint]->any(true));
+	};
+	
 	
 	log('Current number of containers ' + currentSize.toString());
 	

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
@@ -46,7 +46,7 @@ helper Interprete_adjustmentType(adjustment: AdjustmentType, currentSize: Intege
 */
 helper Interprete_GroupSizeConstraints(currentSize:Integer, desiredChange:Real, groupSizeConstraints:TargetGroupSizeConstraint) : Real {
 	assert fatal(groupSizeConstraints.minSize>=1) with log('A minimum below 1 is not permitted for a group size constraints.');
-	assert fatal(groupSizeConstraints.maxSize>1) with log('The maximum group size constraint equal or below 1 is not permitted for a group size constraint.');
+	assert fatal(groupSizeConstraints.maxSize>groupSizeConstraints.minSize) with log('The maximum constraint lower or equal to the minimum is not permitted in a group size constraint.');
 	
 	var modifiedDesiredChange:Real := desiredChange.min(groupSizeConstraints.maxSize-currentSize);
 	modifiedDesiredChange := modifiedDesiredChange.max(groupSizeConstraints.minSize-currentSize);

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/AdjustmentCalculator.qvto
@@ -5,6 +5,8 @@ modeltype SPD_ADJ uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Adj
 modeltype SPD_TRI uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Triggers/1.0';
 modeltype SPD_TAR uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0';
 
+modeltype SPD_CONT uses 'http://palladiosimulator.org/ScalingPolicyDefinition/Constraints/Target/1.0';
+
 /**
 * Interpretation of the AdjustmentType given the currentSize of the TargetGroup. 
 * The interpretation of the AdjustmentType given the currentSize of the target group yields a Ratio value that denotes the desiredChange in capacity for the target group.
@@ -31,6 +33,28 @@ helper Interprete_adjustmentType(adjustment: AdjustmentType, currentSize: Intege
 	};
 	return desiredChange;
 }
+
+/**
+* Interpretation of the GroupSizeConstraints given the currentSize of the TargetGroup and the desiredChange. 
+* The desiredChange is a computation of how many units to add or remove from the target group.
+* The interpretation below bounds the desiredChange so that it yields a number which does not exceed the specified groupSizeConstraints.
+*
+* @param currentSize			The number of elements in the target group.
+* @param desiredChange			The computed desired change given a certain type of adjustment.
+* @param groupSizeConstraints	The TargetGroupSizeConstraint in the model.
+* @return Real 			The modified desired change in capacity for the target group to respect bounds. 
+*/
+helper Interprete_GroupSizeConstraints(currentSize:Integer, desiredChange:Real, groupSizeConstraints:TargetGroupSizeConstraint) : Real {
+	assert fatal(groupSizeConstraints.minSize>=1) with log('A minimum below 1 is not permitted for a group size constraints.');
+	assert fatal(groupSizeConstraints.maxSize>1) with log('The maximum group size constraint equal or below 1 is not permitted for a group size constraint.');
+	
+	var modifiedDesiredChange:Real := desiredChange.min(groupSizeConstraints.maxSize-currentSize);
+	modifiedDesiredChange := modifiedDesiredChange.max(groupSizeConstraints.minSize-currentSize);
+	
+	return modifiedDesiredChange;
+}
+
+
 
 helper caseRelativeAdjustmentType(adjustment: RelativeAdjustment, currentSize: Integer) : Real {
 	var desiredChange : Real := 0;

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationServices.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationServices.qvto
@@ -33,7 +33,7 @@ modeltype SPD_SEM uses 'http://palladiosimulator.org/ScalingPolicyDefinitionSema
 // The mapping transforms the service group configuration, as a side-effect creates new assemblies that are not allocated.
 mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy, system:System){
 	init {
-		var assembliesDiff:OrderedSet(AssemblyContext) := ComputeDiffBasedOnAdjustmentType(self.unit, enactedPolicy.adjustmentType, system, self);
+		var assembliesDiff:OrderedSet(AssemblyContext) := ComputeDiffBasedOnAdjustmentType(self.unit, enactedPolicy, system, self);
 		var newAssemblies:OrderedSet(AssemblyContext) := OrderedSet{};
 		var intersection:Set(AssemblyContext) := self.elements->intersection(assembliesDiff);
 		if(intersection->size()=0){
@@ -64,10 +64,18 @@ mapping inout ServiceGroupCfg::transformServiceGroup(enactedPolicy:ScalingPolicy
 //
 //
 // @return Set(AssemblyContext) assemblies that should be added or removed.
-helper ComputeDiffBasedOnAdjustmentType(unitAssembly:AssemblyContext, adjustment: AdjustmentType, system:System, serviceGroupCfg:ServiceGroupCfg) : OrderedSet(AssemblyContext){
+helper ComputeDiffBasedOnAdjustmentType(unitAssembly:AssemblyContext, policy: ScalingPolicy, system:System, serviceGroupCfg:ServiceGroupCfg) : OrderedSet(AssemblyContext){
 
 	var assembliesDiff : OrderedSet(AssemblyContext) := OrderedSet{};
+	
+	var adjustment: AdjustmentType := policy.adjustmentType;
 	var desiredChange : Real := Interprete_adjustmentType(adjustment, serviceGroupCfg.elements->size());
+	
+	if(policy.targetGroup.targetConstraints[TargetGroupSizeConstraint]->notEmpty()){
+		desiredChange := Interprete_GroupSizeConstraints(serviceGroupCfg.elements->size(),desiredChange,policy.targetGroup.targetConstraints[TargetGroupSizeConstraint]->any(true));
+	};
+	
+	
 	log('Current number of assemblies ' + serviceGroupCfg.elements->size().toString());
 	var uniqueContext:AssemblyContext := unitAssembly;
 	//TODO:Create Assemblies	


### PR DESCRIPTION
Behavior before:

The transformation script did not consider the TargetGroupSizeConstraint in the model. 

Behavior new:

It interpretes the TargetGroupSizeConstraint, when defined, by modifying the desired change to a number that does not exceed the specified minimum and maximum. 
