### PR TITLE
Unit for EI and derived RE

### DIFF
--- a/bundles/org.palladiosimulator.spd.edit/plugin.properties
+++ b/bundles/org.palladiosimulator.spd.edit/plugin.properties
@@ -124,3 +124,4 @@ _UI_IntervalConstraint_intervalDuration_feature = Interval Duration
 _UI_IntervalConstraint_repeat_feature = Repeat
 _UI_CompetingConsumersGroup_unitAssembly_feature = Unit Assembly
 _UI_QueueLength_passiveResource_feature = Passive Resource
+_UI_ElasticInfrastructure_unit_feature = Unit

--- a/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ElasticInfrastructureItemProvider.java
+++ b/bundles/org.palladiosimulator.spd.edit/src/org/palladiosimulator/spd/targets/provider/ElasticInfrastructureItemProvider.java
@@ -42,6 +42,7 @@ public class ElasticInfrastructureItemProvider extends TargetGroupItemProvider {
 			super.getPropertyDescriptors(object);
 
 			addPCM_ResourceEnvironmentPropertyDescriptor(object);
+			addUnitPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -60,6 +61,21 @@ public class ElasticInfrastructureItemProvider extends TargetGroupItemProvider {
 						"_UI_ElasticInfrastructure_PCM_ResourceEnvironment_feature", "_UI_ElasticInfrastructure_type"),
 				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT, true, false, true, null, null,
 				null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Unit feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addUnitPropertyDescriptor(Object object) {
+		itemPropertyDescriptors
+				.add(createItemPropertyDescriptor(((ComposeableAdapterFactory) adapterFactory).getRootAdapterFactory(),
+						getResourceLocator(), getString("_UI_ElasticInfrastructure_unit_feature"),
+						getString("_UI_PropertyDescriptor_description", "_UI_ElasticInfrastructure_unit_feature",
+								"_UI_ElasticInfrastructure_type"),
+						TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__UNIT, true, false, true, null, null, null));
 	}
 
 	/*

--- a/bundles/org.palladiosimulator.spd.tests/src/org/palladiosimulator/spd/targets/tests/ElasticInfrastructureTest.java
+++ b/bundles/org.palladiosimulator.spd.tests/src/org/palladiosimulator/spd/targets/tests/ElasticInfrastructureTest.java
@@ -12,6 +12,12 @@ import junit.textui.TestRunner;
  * <!-- begin-user-doc -->
  * A test case for the model object '<em><b>Elastic Infrastructure</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are tested:
+ * <ul>
+ *   <li>{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment() <em>PCM Resource Environment</em>}</li>
+ * </ul>
+ * </p>
  * @generated
  */
 public class ElasticInfrastructureTest extends TargetGroupTest {
@@ -66,6 +72,58 @@ public class ElasticInfrastructureTest extends TargetGroupTest {
 	@Override
 	protected void tearDown() throws Exception {
 		setFixture(null);
+	}
+
+	/**
+	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment() <em>PCM Resource Environment</em>}' feature getter.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment()
+	 * @generated
+	 */
+	public void testGetPCM_ResourceEnvironment() {
+		// TODO: implement this feature getter test method
+		// Ensure that you remove @generated or mark it @generated NOT
+		fail();
+	}
+
+	/**
+	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#setPCM_ResourceEnvironment(org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment) <em>PCM Resource Environment</em>}' feature setter.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#setPCM_ResourceEnvironment(org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment)
+	 * @generated
+	 */
+	public void testSetPCM_ResourceEnvironment() {
+		// TODO: implement this feature setter test method
+		// Ensure that you remove @generated or mark it @generated NOT
+		fail();
+	}
+
+	/**
+	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#unsetPCM_ResourceEnvironment() <em>unsetPCM_ResourceEnvironment()</em>}' method.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#unsetPCM_ResourceEnvironment()
+	 * @generated
+	 */
+	public void testUnsetPCM_ResourceEnvironment() {
+		// TODO: implement this test method
+		// Ensure that you remove @generated or mark it @generated NOT
+		fail();
+	}
+
+	/**
+	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#isSetPCM_ResourceEnvironment() <em>isSetPCM_ResourceEnvironment()</em>}' method.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#isSetPCM_ResourceEnvironment()
+	 * @generated
+	 */
+	public void testIsSetPCM_ResourceEnvironment() {
+		// TODO: implement this test method
+		// Ensure that you remove @generated or mark it @generated NOT
+		fail();
 	}
 
 } //ElasticInfrastructureTest

--- a/bundles/org.palladiosimulator.spd.tests/src/org/palladiosimulator/spd/targets/tests/ElasticInfrastructureTest.java
+++ b/bundles/org.palladiosimulator.spd.tests/src/org/palladiosimulator/spd/targets/tests/ElasticInfrastructureTest.java
@@ -88,32 +88,6 @@ public class ElasticInfrastructureTest extends TargetGroupTest {
 	}
 
 	/**
-	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#setPCM_ResourceEnvironment(org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment) <em>PCM Resource Environment</em>}' feature setter.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#setPCM_ResourceEnvironment(org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment)
-	 * @generated
-	 */
-	public void testSetPCM_ResourceEnvironment() {
-		// TODO: implement this feature setter test method
-		// Ensure that you remove @generated or mark it @generated NOT
-		fail();
-	}
-
-	/**
-	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#unsetPCM_ResourceEnvironment() <em>unsetPCM_ResourceEnvironment()</em>}' method.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#unsetPCM_ResourceEnvironment()
-	 * @generated
-	 */
-	public void testUnsetPCM_ResourceEnvironment() {
-		// TODO: implement this test method
-		// Ensure that you remove @generated or mark it @generated NOT
-		fail();
-	}
-
-	/**
 	 * Tests the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#isSetPCM_ResourceEnvironment() <em>isSetPCM_ResourceEnvironment()</em>}' method.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/bundles/org.palladiosimulator.spd/model/SPD.ecore
+++ b/bundles/org.palladiosimulator.spd/model/SPD.ecore
@@ -2,7 +2,7 @@
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="spd" nsURI="http://palladiosimulator.org/ScalingPolicyDefinition/1.0"
     nsPrefix="spd">
-  <eClassifiers xsi:type="ecore:EClass" name="ScalingPolicy" eSuperTypes="../../org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
+  <eClassifiers xsi:type="ecore:EClass" name="ScalingPolicy" eSuperTypes="platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="constraints" value="policyNameInvariant"/>
     </eAnnotations>
@@ -19,7 +19,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="scalingTrigger" lowerBound="1"
         eType="#//triggers/ScalingTrigger" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="SPD" eSuperTypes="../../org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
+  <eClassifiers xsi:type="ecore:EClass" name="SPD" eSuperTypes="platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="constraints" value="nameInvariant noSameTargetGroup"/>
     </eAnnotations>
@@ -37,7 +37,7 @@
   </eClassifiers>
   <eSubpackages name="targets" nsURI="http://palladiosimulator.org/ScalingPolicyDefinition/Targets/1.0"
       nsPrefix="targets">
-    <eClassifiers xsi:type="ecore:EClass" name="TargetGroup" abstract="true" eSuperTypes="../../org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
+    <eClassifiers xsi:type="ecore:EClass" name="TargetGroup" abstract="true" eSuperTypes="platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/entity/Entity">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="A TargetGroup defines a management group in SPD. It is both uniqely identified as well as it has a name, thus it extends from the Entity class of the PCM. "/>
       </eAnnotations>
@@ -49,13 +49,15 @@
         <details key="documentation" value="The ElasticInfrastructure target groups resource containers on which components are allocated. The ElasticInfrastructure allows the definition of scaling policies for the whole infrastructure which is a common use case covered by the prominent cloud providers. For example, AWS allows the definition of an Autoscaling Group where EC2 instances are automatically provisioned."/>
       </eAnnotations>
       <eStructuralFeatures xsi:type="ecore:EReference" name="PCM_ResourceEnvironment"
-          eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceEnvironment"/>
+          eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceEnvironment"
+          volatile="true" transient="true" unsettable="true" derived="true"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="unit" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceContainer"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="ServiceGroup" eSuperTypes="#//targets/TargetGroup">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The ServiceGroup groups a set of components that are load balanced and can be horizontally replicated. Upon replication the load balancer distributes the load to the new replicas according to the predefined load balancing strategy."/>
       </eAnnotations>
-      <eStructuralFeatures xsi:type="ecore:EReference" name="unitAssembly" eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="unitAssembly" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="The unitAssembly is used to point to the ServiceGroup in PCM. It is used also for disinguishing between different service groups. A prerequisite is that the unit assembly is already connected in a Service Group structure in PCM. "/>
         </eAnnotations>
@@ -65,7 +67,7 @@
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The CompetingConsumersGroup represents a set of elements that consume messages from a channel/queue asynchronously. In SPD and Palladio it is represented as a set of assembly context that deplete a queue modelled through a PassiveResource. The intention of use behind CompetingConsumersGroup is to represent services that asynchronously process workload by fetching messages from a queue. For understanding the pattern itself one can read https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html.  "/>
       </eAnnotations>
-      <eStructuralFeatures xsi:type="ecore:EReference" name="unitAssembly" eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="unitAssembly" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="The unitAssembly of the CompetingConsumersGroup identifies the AssemblyContext which exists in the System model and which shall be replicated upon scaling out. Furthermore, the unit assembly is the one which will exist throughout the simulation independent of the adaptations. "/>
         </eAnnotations>
@@ -292,7 +294,7 @@
           <details key="documentation" value="A stimulus based on the response time of a given operation. It requires specifying the operationSignature."/>
         </eAnnotations>
         <eStructuralFeatures xsi:type="ecore:EReference" name="operationSignature"
-            eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//repository/OperationSignature">
+            eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//repository/OperationSignature">
           <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
             <details key="documentation" value="The operation from which the response time is used. "/>
           </eAnnotations>
@@ -347,7 +349,7 @@
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="A queue length based stimulus from the source of the target group. A precondition is that the target group is of type CompetingConsumers. "/>
         </eAnnotations>
-        <eStructuralFeatures xsi:type="ecore:EReference" name="passiveResource" eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//repository/PassiveResource"/>
+        <eStructuralFeatures xsi:type="ecore:EReference" name="passiveResource" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//repository/PassiveResource"/>
       </eClassifiers>
       <eClassifiers xsi:type="ecore:EClass" name="NetworkUtilization" eSuperTypes="#//triggers/stimuli/ResourceUtilizationStimulus">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/bundles/org.palladiosimulator.spd/model/SPD.ecore
+++ b/bundles/org.palladiosimulator.spd/model/SPD.ecore
@@ -50,7 +50,7 @@
       </eAnnotations>
       <eStructuralFeatures xsi:type="ecore:EReference" name="PCM_ResourceEnvironment"
           eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceEnvironment"
-          volatile="true" transient="true" unsettable="true" derived="true"/>
+          changeable="false" volatile="true" transient="true" unsettable="true" derived="true"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="unit" eType="ecore:EClass platform:/plugin/org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceContainer"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="ServiceGroup" eSuperTypes="#//targets/TargetGroup">

--- a/bundles/org.palladiosimulator.spd/model/SPD.genmodel
+++ b/bundles/org.palladiosimulator.spd/model/SPD.genmodel
@@ -30,6 +30,8 @@
       <genClasses ecoreClass="SPD.ecore#//targets/ElasticInfrastructure" labelFeature="platform:/plugin/org.palladiosimulator.pcm/model/pcm.genmodel#//pcm/core/entity/NamedElement/entityName">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference SPD.ecore#//targets/ElasticInfrastructure/PCM_ResourceEnvironment"/>
+        <genFeatures notify="false" createChild="false" propertySortChoices="true"
+            ecoreFeature="ecore:EReference SPD.ecore#//targets/ElasticInfrastructure/unit"/>
       </genClasses>
       <genClasses ecoreClass="SPD.ecore#//targets/ServiceGroup" labelFeature="platform:/plugin/org.palladiosimulator.pcm/model/pcm.genmodel#//pcm/core/entity/NamedElement/entityName">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"

--- a/bundles/org.palladiosimulator.spd/model/SPD.ocl
+++ b/bundles/org.palladiosimulator.spd/model/SPD.ocl
@@ -2,9 +2,8 @@ import 'SPD.ecore'
 
 package spd
 
-
 context SPD
-inv antinomicalTargets: self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::ElasticInfrastructure)) xor (self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::CompetingConsumersGroup)) or self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::ServiceGroup)))
+inv antinomicalTargets('Targets in an SPD have either to be multiple service targets or one infrastructure target.'): self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::ElasticInfrastructure)) xor (self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::CompetingConsumersGroup)) or self.targetGroups->exists(t | t.oclIsKindOf(spd::targets::ServiceGroup)))
 inv atLeastOneTarget: self.targetGroups->notEmpty()
 
 context ScalingPolicy
@@ -15,7 +14,7 @@ endpackage
 package spd::targets
 
 context TargetGroup
-inv singleGroupSizeConstraint('The TargetGroup can have only a single TargetGroupSizeConstraint'): self.targetConstraints->collect(x | x.oclIsTypeOf(spd::constraints::target::TargetGroupSizeConstraint))->size()<2
+inv singleGroupSizeConstraint('The TargetGroup can have only a single TargetGroupSizeConstraint.'): self.targetConstraints->collect(x | x.oclIsTypeOf(spd::constraints::target::TargetGroupSizeConstraint))->size()<2
 endpackage
 
 package spd::triggers
@@ -24,15 +23,19 @@ endpackage
 package spd::adjustments
 
 context AbsoluteAdjustment
-inv positiveGoalValue('The AbsoluteAdjustemnt has to specify a positive goal value'): 
+inv positiveGoalValue('The AbsoluteAdjustemnt has to specify a positive goal value.'): 
 	self.goalValue>0
 
 context RelativeAdjustment
-inv nonZeroValue('The minAdjustmentValue for a RelativeAdjustment must not be zero'): 
+inv nonZeroValue('The minAdjustmentValue for a RelativeAdjustment must not be zero.'): 
 	self.minAdjustmentValue<>0
+	
+inv sameSign('The minAdjustmentValue and percentageGrowthValue must be of the same sign.'):
+	(self.percentageGrowthValue>0 implies self.minAdjustmentValue>0) and (self.percentageGrowthValue<0 implies self.minAdjustmentValue<0)
+    
 
 context StepAdjustment
-inv nonZeroValue('The stepValue for StepAdjustment must not be zero'): 
+inv nonZeroValue('The stepValue for StepAdjustment must not be zero.'): 
 	self.stepValue<>0
 
 endpackage

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ElasticInfrastructure.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ElasticInfrastructure.java
@@ -34,45 +34,18 @@ public interface ElasticInfrastructure extends TargetGroup {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>PCM Resource Environment</em>' reference.
 	 * @see #isSetPCM_ResourceEnvironment()
-	 * @see #unsetPCM_ResourceEnvironment()
-	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
 	 * @see org.palladiosimulator.spd.targets.TargetsPackage#getElasticInfrastructure_PCM_ResourceEnvironment()
-	 * @model unsettable="true" transient="true" volatile="true" derived="true"
+	 * @model unsettable="true" transient="true" changeable="false" volatile="true" derived="true"
 	 * @generated
 	 */
 	ResourceEnvironment getPCM_ResourceEnvironment();
-
-	/**
-	 * Sets the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>PCM Resource Environment</em>' reference.
-	 * @see #isSetPCM_ResourceEnvironment()
-	 * @see #unsetPCM_ResourceEnvironment()
-	 * @see #getPCM_ResourceEnvironment()
-	 * @generated
-	 */
-	void setPCM_ResourceEnvironment(ResourceEnvironment value);
-
-	/**
-	 * Unsets the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #isSetPCM_ResourceEnvironment()
-	 * @see #getPCM_ResourceEnvironment()
-	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
-	 * @generated
-	 */
-	void unsetPCM_ResourceEnvironment();
 
 	/**
 	 * Returns whether the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}' reference is set.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return whether the value of the '<em>PCM Resource Environment</em>' reference is set.
-	 * @see #unsetPCM_ResourceEnvironment()
 	 * @see #getPCM_ResourceEnvironment()
-	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
 	 * @generated
 	 */
 	boolean isSetPCM_ResourceEnvironment();

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ElasticInfrastructure.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/ElasticInfrastructure.java
@@ -3,6 +3,7 @@
  */
 package org.palladiosimulator.spd.targets;
 
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
 
 /**
@@ -19,6 +20,7 @@ import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
  * </p>
  * <ul>
  *   <li>{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}</li>
+ *   <li>{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getUnit <em>Unit</em>}</li>
  * </ul>
  *
  * @see org.palladiosimulator.spd.targets.TargetsPackage#getElasticInfrastructure()
@@ -31,9 +33,11 @@ public interface ElasticInfrastructure extends TargetGroup {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>PCM Resource Environment</em>' reference.
+	 * @see #isSetPCM_ResourceEnvironment()
+	 * @see #unsetPCM_ResourceEnvironment()
 	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
 	 * @see org.palladiosimulator.spd.targets.TargetsPackage#getElasticInfrastructure_PCM_ResourceEnvironment()
-	 * @model
+	 * @model unsettable="true" transient="true" volatile="true" derived="true"
 	 * @generated
 	 */
 	ResourceEnvironment getPCM_ResourceEnvironment();
@@ -43,9 +47,56 @@ public interface ElasticInfrastructure extends TargetGroup {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @param value the new value of the '<em>PCM Resource Environment</em>' reference.
+	 * @see #isSetPCM_ResourceEnvironment()
+	 * @see #unsetPCM_ResourceEnvironment()
 	 * @see #getPCM_ResourceEnvironment()
 	 * @generated
 	 */
 	void setPCM_ResourceEnvironment(ResourceEnvironment value);
+
+	/**
+	 * Unsets the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isSetPCM_ResourceEnvironment()
+	 * @see #getPCM_ResourceEnvironment()
+	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
+	 * @generated
+	 */
+	void unsetPCM_ResourceEnvironment();
+
+	/**
+	 * Returns whether the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}' reference is set.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return whether the value of the '<em>PCM Resource Environment</em>' reference is set.
+	 * @see #unsetPCM_ResourceEnvironment()
+	 * @see #getPCM_ResourceEnvironment()
+	 * @see #setPCM_ResourceEnvironment(ResourceEnvironment)
+	 * @generated
+	 */
+	boolean isSetPCM_ResourceEnvironment();
+
+	/**
+	 * Returns the value of the '<em><b>Unit</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Unit</em>' reference.
+	 * @see #setUnit(ResourceContainer)
+	 * @see org.palladiosimulator.spd.targets.TargetsPackage#getElasticInfrastructure_Unit()
+	 * @model
+	 * @generated
+	 */
+	ResourceContainer getUnit();
+
+	/**
+	 * Sets the value of the '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getUnit <em>Unit</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Unit</em>' reference.
+	 * @see #getUnit()
+	 * @generated
+	 */
+	void setUnit(ResourceContainer value);
 
 } // ElasticInfrastructure

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/TargetsPackage.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/TargetsPackage.java
@@ -149,13 +149,22 @@ public interface TargetsPackage extends EPackage {
 	int ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT = TARGET_GROUP_FEATURE_COUNT + 0;
 
 	/**
+	 * The feature id for the '<em><b>Unit</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ELASTIC_INFRASTRUCTURE__UNIT = TARGET_GROUP_FEATURE_COUNT + 1;
+
+	/**
 	 * The number of structural features of the '<em>Elastic Infrastructure</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int ELASTIC_INFRASTRUCTURE_FEATURE_COUNT = TARGET_GROUP_FEATURE_COUNT + 1;
+	int ELASTIC_INFRASTRUCTURE_FEATURE_COUNT = TARGET_GROUP_FEATURE_COUNT + 2;
 
 	/**
 	 * The meta object id for the '{@link org.palladiosimulator.spd.targets.impl.ServiceGroupImpl <em>Service Group</em>}' class.
@@ -310,6 +319,17 @@ public interface TargetsPackage extends EPackage {
 	EReference getElasticInfrastructure_PCM_ResourceEnvironment();
 
 	/**
+	 * Returns the meta object for the reference '{@link org.palladiosimulator.spd.targets.ElasticInfrastructure#getUnit <em>Unit</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the reference '<em>Unit</em>'.
+	 * @see org.palladiosimulator.spd.targets.ElasticInfrastructure#getUnit()
+	 * @see #getElasticInfrastructure()
+	 * @generated
+	 */
+	EReference getElasticInfrastructure_Unit();
+
+	/**
 	 * Returns the meta object for class '{@link org.palladiosimulator.spd.targets.ServiceGroup <em>Service Group</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -409,6 +429,14 @@ public interface TargetsPackage extends EPackage {
 		 */
 		EReference ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT = eINSTANCE
 				.getElasticInfrastructure_PCM_ResourceEnvironment();
+
+		/**
+		 * The meta object literal for the '<em><b>Unit</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference ELASTIC_INFRASTRUCTURE__UNIT = eINSTANCE.getElasticInfrastructure_Unit();
 
 		/**
 		 * The meta object literal for the '{@link org.palladiosimulator.spd.targets.impl.ServiceGroupImpl <em>Service Group</em>}' class.

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ElasticInfrastructureImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ElasticInfrastructureImpl.java
@@ -67,43 +67,19 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 		// -> do not perform proxy resolution
 		// Ensure that you remove @generated or mark it @generated NOT
 		return this.getUnit().getResourceEnvironment_ResourceContainer();
-//		throw new UnsupportedOperationException();
+		//		throw new UnsupportedOperationException();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public void setPCM_ResourceEnvironment(ResourceEnvironment newPCM_ResourceEnvironment) {
-		// TODO: implement this method to set the 'PCM Resource Environment' reference
-		// Ensure that you remove @generated or mark it @generated NOT
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public void unsetPCM_ResourceEnvironment() {
-		// TODO: implement this method to unset the 'PCM Resource Environment' reference
-		// Ensure that you remove @generated or mark it @generated NOT
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public boolean isSetPCM_ResourceEnvironment() {
 		// TODO: implement this method to return whether the 'PCM Resource Environment' reference is set
 		// Ensure that you remove @generated or mark it @generated NOT
-		throw new UnsupportedOperationException();
+		return basicGetUnit().getResourceEnvironment_ResourceContainer() != null;
 	}
 
 	/**
@@ -166,9 +142,6 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-		case TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT:
-			setPCM_ResourceEnvironment((ResourceEnvironment) newValue);
-			return;
 		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
 			setUnit((ResourceContainer) newValue);
 			return;
@@ -184,9 +157,6 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-		case TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT:
-			unsetPCM_ResourceEnvironment();
-			return;
 		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
 			setUnit((ResourceContainer) null);
 			return;

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ElasticInfrastructureImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/ElasticInfrastructureImpl.java
@@ -4,6 +4,8 @@
 package org.palladiosimulator.spd.targets.impl;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
 import org.palladiosimulator.spd.targets.ElasticInfrastructure;
 import org.palladiosimulator.spd.targets.TargetsPackage;
@@ -17,6 +19,7 @@ import org.palladiosimulator.spd.targets.TargetsPackage;
  * </p>
  * <ul>
  *   <li>{@link org.palladiosimulator.spd.targets.impl.ElasticInfrastructureImpl#getPCM_ResourceEnvironment <em>PCM Resource Environment</em>}</li>
+ *   <li>{@link org.palladiosimulator.spd.targets.impl.ElasticInfrastructureImpl#getUnit <em>Unit</em>}</li>
  * </ul>
  *
  * @generated
@@ -48,18 +51,23 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	 */
 	@Override
 	public ResourceEnvironment getPCM_ResourceEnvironment() {
-		return (ResourceEnvironment) eDynamicGet(TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT,
-				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT, true, true);
+		ResourceEnvironment pcM_ResourceEnvironment = basicGetPCM_ResourceEnvironment();
+		return pcM_ResourceEnvironment != null && pcM_ResourceEnvironment.eIsProxy()
+				? (ResourceEnvironment) eResolveProxy((InternalEObject) pcM_ResourceEnvironment)
+				: pcM_ResourceEnvironment;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	public ResourceEnvironment basicGetPCM_ResourceEnvironment() {
-		return (ResourceEnvironment) eDynamicGet(TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT,
-				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT, false, true);
+		// TODO: implement this method to return the 'PCM Resource Environment' reference
+		// -> do not perform proxy resolution
+		// Ensure that you remove @generated or mark it @generated NOT
+		return this.getUnit().getResourceEnvironment_ResourceContainer();
+//		throw new UnsupportedOperationException();
 	}
 
 	/**
@@ -69,8 +77,65 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	 */
 	@Override
 	public void setPCM_ResourceEnvironment(ResourceEnvironment newPCM_ResourceEnvironment) {
-		eDynamicSet(TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT,
-				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT, newPCM_ResourceEnvironment);
+		// TODO: implement this method to set the 'PCM Resource Environment' reference
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void unsetPCM_ResourceEnvironment() {
+		// TODO: implement this method to unset the 'PCM Resource Environment' reference
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean isSetPCM_ResourceEnvironment() {
+		// TODO: implement this method to return whether the 'PCM Resource Environment' reference is set
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public ResourceContainer getUnit() {
+		return (ResourceContainer) eDynamicGet(TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT,
+				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__UNIT, true, true);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public ResourceContainer basicGetUnit() {
+		return (ResourceContainer) eDynamicGet(TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT,
+				TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__UNIT, false, true);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setUnit(ResourceContainer newUnit) {
+		eDynamicSet(TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT, TargetsPackage.Literals.ELASTIC_INFRASTRUCTURE__UNIT,
+				newUnit);
 	}
 
 	/**
@@ -85,6 +150,10 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 			if (resolve)
 				return getPCM_ResourceEnvironment();
 			return basicGetPCM_ResourceEnvironment();
+		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
+			if (resolve)
+				return getUnit();
+			return basicGetUnit();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -100,6 +169,9 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 		case TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT:
 			setPCM_ResourceEnvironment((ResourceEnvironment) newValue);
 			return;
+		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
+			setUnit((ResourceContainer) newValue);
+			return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -113,7 +185,10 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	public void eUnset(int featureID) {
 		switch (featureID) {
 		case TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT:
-			setPCM_ResourceEnvironment((ResourceEnvironment) null);
+			unsetPCM_ResourceEnvironment();
+			return;
+		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
+			setUnit((ResourceContainer) null);
 			return;
 		}
 		super.eUnset(featureID);
@@ -128,7 +203,9 @@ public class ElasticInfrastructureImpl extends TargetGroupImpl implements Elasti
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 		case TargetsPackage.ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT:
-			return basicGetPCM_ResourceEnvironment() != null;
+			return isSetPCM_ResourceEnvironment();
+		case TargetsPackage.ELASTIC_INFRASTRUCTURE__UNIT:
+			return basicGetUnit() != null;
 		}
 		return super.eIsSet(featureID);
 	}

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
@@ -383,7 +383,7 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getElasticInfrastructure_PCM_ResourceEnvironment(),
 				theResourceenvironmentPackage.getResourceEnvironment(), null, "PCM_ResourceEnvironment", null, 0, 1,
-				ElasticInfrastructure.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+				ElasticInfrastructure.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE,
 				IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 		initEReference(getElasticInfrastructure_Unit(), theResourceenvironmentPackage.getResourceContainer(), null,
 				"unit", null, 0, 1, ElasticInfrastructure.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/targets/impl/TargetsPackageImpl.java
@@ -242,6 +242,16 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 	 * @generated
 	 */
 	@Override
+	public EReference getElasticInfrastructure_Unit() {
+		return (EReference) elasticInfrastructureEClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EClass getServiceGroup() {
 		return serviceGroupEClass;
 	}
@@ -311,6 +321,7 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 
 		elasticInfrastructureEClass = createEClass(ELASTIC_INFRASTRUCTURE);
 		createEReference(elasticInfrastructureEClass, ELASTIC_INFRASTRUCTURE__PCM_RESOURCE_ENVIRONMENT);
+		createEReference(elasticInfrastructureEClass, ELASTIC_INFRASTRUCTURE__UNIT);
 
 		serviceGroupEClass = createEClass(SERVICE_GROUP);
 		createEReference(serviceGroupEClass, SERVICE_GROUP__UNIT_ASSEMBLY);
@@ -372,8 +383,11 @@ public class TargetsPackageImpl extends EPackageImpl implements TargetsPackage {
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getElasticInfrastructure_PCM_ResourceEnvironment(),
 				theResourceenvironmentPackage.getResourceEnvironment(), null, "PCM_ResourceEnvironment", null, 0, 1,
-				ElasticInfrastructure.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				ElasticInfrastructure.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+				IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getElasticInfrastructure_Unit(), theResourceenvironmentPackage.getResourceContainer(), null,
+				"unit", null, 0, 1, ElasticInfrastructure.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+				!IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(serviceGroupEClass, ServiceGroup.class, "ServiceGroup", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);


### PR DESCRIPTION
In this PR, we require a unit resource container as a reference for the Elastic Infrastructure. With the addition of the unit, we make the resource environment reference as derived. This is a requirement of #19. 

Considerations about breaking the backward compatibility: All previous SPD models must explicitly set the unit resource container to comply with this change. 

In this PR, there are some minor additions to the constraints, which can be merged. 