### PR TITLE
supporting multiple elastic homogenous infrastructure

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
@@ -5,3 +5,5 @@ Bundle-SymbolicName: org.palladiosimulator.spd.semantic.transformations;singleto
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.spd.semantic.transformations
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Export-Package: pcm.helpers
+Require-Bundle: org.eclipse.m2m.qvt.oml.runtime

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/plugin.xml
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/plugin.xml
@@ -7,5 +7,12 @@
             path="transformations/">
       </sourceContainer>
    </extension>
+   <extension
+         point="org.eclipse.m2m.qvt.oml.runtime.qvtTransformation">
+      <transformation
+            file="transformations/pcm/helpers/Loadbalancing.qvto"
+            id="org.palladiosimulator.spd.semantic.transformations.pcm.helpers.Loadbalancing">
+      </transformation>
+   </extension>
 
 </plugin>

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Constructors.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Constructors.qvto
@@ -177,6 +177,37 @@ constructor BasicComponent :: BasicComponent (loadBalancedComponent : Repository
 	}
 }
 
+
+/*
+* Constructor of PBT that also copies the children of the ExternalCallAction i.e., variable characterizations.
+*/
+constructor ProbabilisticBranchTransition :: ProbabilisticBranchTransition (operationSignature:OperationSignature, reqRole:OperationRequiredRole, originalExtCallAction : ExternalCallAction) {
+	entityName := "Branch for "+ reqRole.entityName;
+	branchProbability := 1.0;
+	log('size of inputvar '+ originalExtCallAction.inputVariableUsages__CallAction->size().toString());
+    branchBehaviour_BranchTransition := object ResourceDemandingBehaviour{
+    	var innerStartAction : StartAction := object StartAction{};
+    	var delegatingExternalCallAction : ExternalCallAction := object ExternalCallAction{
+    		predecessor_AbstractAction := innerStartAction;
+    		entityName := "Call "+ operationSignature.entityName;
+    		role_ExternalService := reqRole;
+    		calledService_ExternalService := operationSignature;
+    		inputVariableUsages__CallAction := originalExtCallAction.inputVariableUsages__CallAction.deepclone();
+    		
+    	};
+    	var innerStopAction : StopAction := object StopAction{
+			predecessor_AbstractAction := delegatingExternalCallAction;
+		};
+		
+		
+		steps_Behaviour += innerStartAction;
+		steps_Behaviour += delegatingExternalCallAction;
+		steps_Behaviour += innerStopAction;
+    };
+}
+
+
+
 constructor ProbabilisticBranchTransition :: ProbabilisticBranchTransition (operationSignature:OperationSignature, reqRole:OperationRequiredRole) {
 	entityName := "Branch for "+ reqRole.entityName;
 	branchProbability := 1.0;
@@ -197,6 +228,9 @@ constructor ProbabilisticBranchTransition :: ProbabilisticBranchTransition (oper
 		steps_Behaviour += innerStopAction;
     };
 }
+
+
+
 
 constructor BranchTransition :: BranchTransition (operationSignature:OperationSignature, providedRole:OperationProvidedRole) {
 	branchProbability := 1.0;

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Loadbalancing.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/pcm/helpers/Loadbalancing.qvto
@@ -34,7 +34,7 @@ property loadbalancerAssemblyContextStereotype : String = "LoadbalancerAssemblyC
 property duplicateAssemblyContextStereotype : String = "DuplicateAssemblyContext";
 
 
-property numberOfReplicas : Integer;
+property numberOfReplicas : Integer = 1;
 
 main() {
 	var allocation : Allocation := pcmAllocation.rootObjects()![Allocation];

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformation.qvto
@@ -54,7 +54,12 @@ main() {
 		// Modify infrastructure
 		// *********************
 		var invariantResourceContainers:Set(ResourceContainer) := Set{};		
-		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(true);
+	
+	
+		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(target | target.unit.id = cfg.enactedPolicy.targetGroup.oclAsType(ElasticInfrastructure).unit.id);
+		assert fatal(elasticInfrastructureCfg!=null) with log('No ElasticInfrastructureCfg exist with the same unit on which the policy applies. Please configure the elastic environment appropriatly.');
+			
+	
 		resourceEnvironment.resourceContainer_ResourceEnvironment->forEach(rc){
 			if(elasticInfrastructureCfg.elements->excludes(rc)){
 				invariantResourceContainers += rc;		
@@ -67,12 +72,18 @@ main() {
 		// *******************************
 		// Modify simulated service groups
 		// *******************************
-		cfg.targetCfgs[ServiceGroupCfg]->map transformServiceGroup(cfg.enactedPolicy, elasticInfrastructureCfg, system, allocation);
 		
-		cfg.targetCfgs[CompetingConsumersGroupCfg]->map transformCompetingConsumersGroup(cfg.enactedPolicy, elasticInfrastructureCfg, system, allocation);
+		//** Filter Service Groups and Competing Consumer Groups only for those contained in the unit of the homegenous elastic infrastructure **
+		var allocations : Set(AllocationContext) = allocation.allocationContexts_Allocation->select(alloc | alloc.resourceContainer_AllocationContext.id = elasticInfrastructureCfg.unit.id);
+		var assembliesInUnit : Bag(AssemblyContext) = allocations.assemblyContext_AllocationContext;
+		
+		cfg.targetCfgs[ServiceGroupCfg]->select(cfgs | assembliesInUnit->includes(cfgs.unit))->map transformServiceGroup(cfg.enactedPolicy, elasticInfrastructureCfg, system, allocation);
+		cfg.targetCfgs[CompetingConsumersGroupCfg]->select(cfgs | assembliesInUnit->includes(cfgs.unit))->map transformCompetingConsumersGroup(cfg.enactedPolicy, elasticInfrastructureCfg, system, allocation);
 }
 
 helper homogeneous_environment_assertion(){
+
+	//TODO:: Check that each element of the elastic infra are homegenous, that is: they host replicated services and competing queue consumers
 	
 }
 

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/ServiceGroupRepositoryTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/ServiceGroupRepositoryTransformation.qvto
@@ -91,8 +91,9 @@ mapping inout BranchAction::modifyBranchAction(serviceGroupCfg:ServiceGroupCfg, 
 	init {
 		var newProbabilisticBranches:Set(ProbabilisticBranchTransition) := Set{};
 		newRoles->forEach(role){
+			var existingExtCall : ExternalCallAction := self.branches_Branch.branchBehaviour_BranchTransition.steps_Behaviour[ExternalCallAction]->any(true);
 			var operationSignature:OperationSignature := self.branches_Branch.branchBehaviour_BranchTransition.steps_Behaviour[ExternalCallAction]->any(true).calledService_ExternalService;
-			newProbabilisticBranches += new ProbabilisticBranchTransition(operationSignature,role);
+			newProbabilisticBranches += new ProbabilisticBranchTransition(operationSignature,role,existingExtCall);
 		}	
 	}
 	branches_Branch += newProbabilisticBranches;

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/queries/TargetGroupQueries.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/common/queries/TargetGroupQueries.qvto
@@ -52,10 +52,10 @@ query OrderedSet(TargetGroupCfg)::retrieveServiceTargetCfgOfPolicy(policy:Scalin
 query TargetGroup::retrieveUnit():AssemblyContext {
 	switch { 
 		case (self.oclIsKindOf(ServiceGroup)) {
-			return self.oclAsType(ServiceGroup).unitAssembly;		
+			return self.oclAsType(ServiceGroup).unitAssembly.oclAsType(AssemblyContext);		
 		} 
 		case (self.oclIsKindOf(CompetingConsumersGroup)) {
-			return self.oclAsType(CompetingConsumersGroup).unitAssembly;
+			return self.oclAsType(CompetingConsumersGroup).unitAssembly.oclAsType(AssemblyContext);
 		} 
 	};
 	return assert fatal (false) with log('cannot retrieve unit assembly for non-services');	

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformation.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformation.qvto
@@ -53,9 +53,11 @@ main(){
 		
 		var currentNumberOfElements : Integer := serviceTargetCfg.numberOfElements();
 		
+		
 		switch {
 			case (serviceTargetCfg.oclIsKindOf(ServiceGroupCfg)) {
 				serviceTargetCfg.oclAsType(ServiceGroupCfg).map transformServiceGroup(cfg.enactedPolicy, system);
+				
 			};
 			case (serviceTargetCfg.oclIsKindOf(CompetingConsumersGroupCfg)) {
 				serviceTargetCfg.oclAsType(CompetingConsumersGroupCfg).map transformCompetingConsumersGroup(cfg.enactedPolicy, system);
@@ -65,15 +67,44 @@ main(){
 		// *************
 		// Transform Elastic Infrastructure Accordingly 
 		// *************	
+		
+		
+		
+		
+		//** Pick the elastic infrastructure in which the unit of the service is allocated on the unit of the infrastructure.		
+		var unitAssembly : AssemblyContext = serviceTargetCfg.retrieveUnit();
+		var unitResourceContainer : ResourceContainer = allocation.allocationContexts_Allocation->any(alloc | alloc.assemblyContext_AllocationContext.id = unitAssembly.id).resourceContainer_AllocationContext;
+		
+		
+		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(target | target.unit.id = unitResourceContainer.id);
+		assert fatal(elasticInfrastructureCfg!=null) with log('No ElasticInfrastructureCfg exist which its unit hosts the unit of the service group.');
+				
+		
+		// *************
+		// Placement Heuristic
+		// *************
+		
+		// The number of allocations initially hosted on the unit container without load balancing allocations and others not part of service groups.
+		var unitAssemblies : Sequence(AssemblyContext) := cfg.targetCfgs[ServiceGroupCfg].unit->union(cfg.targetCfgs[CompetingConsumersGroupCfg].unit);
+		var serviceAssemblies : Sequence(AssemblyContext) := cfg.targetCfgs[ServiceGroupCfg].elements->union(cfg.targetCfgs[CompetingConsumersGroupCfg].elements);
+		
+		// count only unit assemblies of services allocated on the unit resource container to determine the initial size of service replicas
+		var max_assemblies_per_host : Integer = allocation.allocationContexts_Allocation
+												->select(allocs | allocs.resourceContainer_AllocationContext.id = elasticInfrastructureCfg.unit.id)
+												->select(alloc | unitAssemblies->includes(alloc.assemblyContext_AllocationContext))->size();
+		
+		
+		log("Placement Constraints: Max Assemblies Per Host "+max_assemblies_per_host.toString());
+												
+		
 		var invariantResourceContainers:Set(ResourceContainer) := Set{};		
-		var elasticInfrastructureCfg : ElasticInfrastructureCfg := cfg.targetCfgs[ElasticInfrastructureCfg]->any(true);
 		resourceEnvironment.resourceContainer_ResourceEnvironment->forEach(rc){
 			if(elasticInfrastructureCfg.elements->excludes(rc)){
 				invariantResourceContainers += rc;		
 			};
 		};
 		
-		elasticInfrastructureCfg.map transformElasticInfrastructure(cfg.enactedPolicy, serviceTargetCfg, allocation);
+		elasticInfrastructureCfg.map transformElasticInfrastructure(cfg.enactedPolicy, serviceTargetCfg, allocation, max_assemblies_per_host, serviceAssemblies);
 		allocation.map modifyAllocation(serviceTargetCfg, elasticInfrastructureCfg, serviceTargetCfg.numberOfElements()-currentNumberOfElements);
 		resourceEnvironment.map modifyResourceEnvironment(elasticInfrastructureCfg, invariantResourceContainers);
 }

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
@@ -34,7 +34,7 @@ property max_assemblies_per_host : Integer = 3;
 * The ElasticInfrastructureCfg is modified by transforming the elements and adding the policy to the enactedPolicies.
 *
 */
-mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPolicy:ScalingPolicy, serviceGroupCfg:TargetGroupCfg, allocation:Allocation){
+mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPolicy:ScalingPolicy, serviceGroupCfg:TargetGroupCfg, allocation:Allocation, maxAssembliesPerHost:Integer, allServiceAssemblies:Sequence(AssemblyContext)){
 	init{
 		var resourceContainersToAdd:Set(ResourceContainer) := Set{};
 		var resourceContainersToRemove:Set(ResourceContainer) := Set{};
@@ -45,6 +45,11 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 		
 		var allocationsTotal:Set(AllocationContext) := allocation.allocationContexts_Allocation->select(alloc | self.elements->includes(alloc.resourceContainer_AllocationContext));
 		var allocationsOfService:Set(AllocationContext) := allocation.allocationContexts_Allocation->select(alloc | serviceGroupAssemblies->includes(alloc.assemblyContext_AllocationContext));
+		
+		var allocationsInUnit:Set(AllocationContext) := allocation.allocationContexts_Allocation->select(alloc | self.unit.id = alloc.resourceContainer_AllocationContext.id);
+		
+		this.max_assemblies_per_host := maxAssembliesPerHost;
+		
 		
 		/* 
 		* in case allocations match elements then no scale out has happened, 
@@ -61,10 +66,15 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 			// scale out infrastructure if needed
 			// create new if the diff cannot be accomodated considering the constraint which currently is fixed in the script to 3. See max_assemblies_per_host.
 			
-			var currentAllocations:Integer := allocation.allocationContexts_Allocation->select(alloc | self.elements->includes(alloc.resourceContainer_AllocationContext))->size();
+			// Note: current service allocations is the number of allocations of configured elastic services, assemblies that reside in the infrastructure that do not co-scale are not taken into account.
+			var currentServiceAllocations:Integer := allocation.allocationContexts_Allocation
+												->select(alloc | self.elements->includes(alloc.resourceContainer_AllocationContext))
+												->select(alloc | allServiceAssemblies->includes(alloc.assemblyContext_AllocationContext))
+												->size();
+												
 			var newElements:Integer := serviceGroupCfg.numberOfElements() - allocationsOfService->size();
 			
-			var totalAllocationsAfterAdjustment:Integer := currentAllocations+newElements;
+			var totalAllocationsAfterAdjustment:Integer := currentServiceAllocations+newElements;
 			
 			//placement constraints
 			var numberOfContainers:Integer := totalAllocationsAfterAdjustment.div(max_assemblies_per_host);


### PR DESCRIPTION
Through this PR, we support the definition of multiple elastic infrastructures in one SPD. 

The elastic infrastructures are modified independently without affecting each other. Only the services that reside in one elastic and homogenous infrastructure are modified; the other services are kept untouched. 

In addition, this PR contains two minor changes that were too small to have their own PR:
* a workaround fix for the compilation error in the base eclipse in the TargetGroupQueries. Please check if it compiles now also at your end. 
* Export the transformation script utilities that may be used from other projects. I used that to transform one model to fit the prerequisites of SPD programmatically. 