### PR TITLE
Fix for danling allocations on scale in

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
@@ -146,8 +146,9 @@ mapping inout Allocation::modifyAllocationOnScaleIn(serviceGroupCfg:TargetGroupC
 when{scaling<0;}
 {
 	init {
-		// when system model is updated and assemblies are removed, the allocation model is transformed as well by making the ctxts with assemblies with nullablle components.  
-		var allocationsWithNullComponent:Set(AllocationContext) := self.allocationContexts_Allocation->select(allocCtxt | allocCtxt.assemblyContext_AllocationContext.encapsulatedComponent__AssemblyContext=null);
+		var serviceAllocs:Set(AllocationContext) := self.allocationContexts_Allocation->select(allocs | serviceGroupCfg.retrieveAssemblyElements()->includes(allocs.assemblyContext_AllocationContext));
+		var allServiceAllocs:Set(AllocationContext) := self.allocationContexts_Allocation->select(alloc | alloc.assemblyContext_AllocationContext.encapsulatedComponent__AssemblyContext = serviceGroupCfg->retrieveUnit()->any(true).encapsulatedComponent__AssemblyContext);
+		var allocationsToRemove:Set(AllocationContext) := allServiceAllocs - serviceAllocs;
 	}
-	allocationContexts_Allocation := self.allocationContexts_Allocation - allocationsWithNullComponent;
+	allocationContexts_Allocation := self.allocationContexts_Allocation - allocationsToRemove;
 }


### PR DESCRIPTION
### Before

Bug: Allocations were not properly removed when scaling in.

### Behavior now

Bug fix: transformation script for allocation model of top-down transformations in case of scaling in.
