### PR TITLE
Modified build properties to incl. Transformations

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/META-INF/MANIFEST.MF
@@ -5,5 +5,6 @@ Bundle-SymbolicName: org.palladiosimulator.spd.semantic.transformations;singleto
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.spd.semantic.transformations
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Export-Package: pcm.helpers
+Export-Package: pcm.helpers,
+ spd
 Require-Bundle: org.eclipse.m2m.qvt.oml.runtime

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+			   .,\
+			   transformations/


### PR DESCRIPTION
Instead of duplicating QVTo transformations in src/main/resources so that they are present when building through Maven (see https://github.com/PalladioSimulator/Palladio-Addons-SPD-Metamodel/pull/28), I have added them to the build.properties configuration file. 

I have tested this and works properly on my side.

