### PR TITLE
Fix settings for export as feature

### DIFF
--- a/bundles/org.palladiosimulator.spd.measuringpoint.edit/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.spd.measuringpoint.edit/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.palladiosimulator.spdmeasuringpoint.provider.SpdmeasuringpointEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.palladiosimulator.spdmeasuringpoint.provider
 Require-Bundle: org.eclipse.core.runtime,
  org.palladiosimulator.spd.measuringpoint;visibility:=reexport,

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/build.properties
@@ -1,5 +1,5 @@
-source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-			   .,\
-			   transformations/
+               .,\
+               transformations/,\
+               plugin.xml


### PR DESCRIPTION
Minor fixes in manifest and build files. 

I discovered these mistakes while attempting to export the entire SPD repo a a installable feature. With these fixes, it worked for me.