### PR TITLE
Ensure truly unique naming of resource containers

### DIFF
--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/bottomup/BottomUpTransformationInfrastructure.qvto
@@ -85,7 +85,7 @@ helper AdjustElasticInfrastructure(policy: ScalingPolicy, elasticInfrastructureC
 		var i : Integer := 0;
 		while (i < desiredChange) {
 			log('lets create');		
-			var resourceContainer := new ResourceContainer(elasticInfrastructureCfg.unit,Commons_getUniqueElementNameSuffix());
+			var resourceContainer := new ResourceContainer(elasticInfrastructureCfg.unit,"_" + (elasticInfrastructureCfg.elements->size() + i).toString());
 			resourceContainers += resourceContainer;
 			i := i + 1;
 		};						

--- a/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
+++ b/bundles/org.palladiosimulator.spd.semantic.transformations/transformations/spd/topdown/TopDownTransformationInfrastructure.qvto
@@ -87,7 +87,7 @@ mapping inout ElasticInfrastructureCfg::transformElasticInfrastructure(enactedPo
 			var difference:Integer := numberOfContainers - self.elements->size();
 			var i:Integer :=0;		
 			while(i<difference){
-				var resourceContainer := new ResourceContainer(self.unit, Commons_getUniqueElementNameSuffix());
+				var resourceContainer := new ResourceContainer(self.unit, "_" + (currentServiceAllocations + i).toString());
 				resourceContainersToAdd += resourceContainer;
 				i := i+1;
 			};


### PR DESCRIPTION
The previous method had unique naming per scaling action, if two scaling
actions occured, the uniqueness wasn't guaranteed anymore because a
counter was reset. This approach should guarantee uniqueness even when
the same infrastructure is scaled multiple times.